### PR TITLE
Handling Runner edge case

### DIFF
--- a/lint-workflow/lint.py
+++ b/lint-workflow/lint.py
@@ -27,7 +27,7 @@ def lint(filename):
 
                 # Make sure runner is using pinned version.
                 runner = job["runs-on"]
-                if runner.split("-")[1] == "latest":
+                if "-latest" in runner:
                     findings.append(
                         f"- Runner version is set to '{runner}', but needs to be pinned to a version."
                     )


### PR DESCRIPTION
## Summary

There is an edge case that I found for the runner being set to `${{ matrix.os }}`. This change fixes that edge case.