### PR TITLE
Checks Run value, alert user if it needs to be a single line

### DIFF
--- a/lint-workflow/lint.py
+++ b/lint-workflow/lint.py
@@ -86,6 +86,12 @@ def lint(filename):
                             findings.append(
                                 f"- Step {str(i)} of job key '{job_key}' does not have a valid action hash. (missing '@' character)"
                             )
+                    # If the step has a 'run' key and only has one command, check if it's a single line.
+                    if "run" in step:
+                        if step["run"].count('\n') == 1:
+                            findings.append(
+                                f"- Run in step {str(i)} of job key '{job_key}' should be a single line."
+                            )
 
     if len(findings) > 0:
         print("#", filename)


### PR DESCRIPTION
Adds in logic to the `lint.py` script to check Run commands. If there is only a single run command but is on multiple lines, a message will be appended to `findings` to fix the format of the command.

Example:
```yml
      - name: Test
        run: |
          echo "Hello World!"
``` 

Should be
```yml
      - name: Test
        run:  echo "Hello World!"
``` 