### PR TITLE
Add get-release-version action

### DIFF
--- a/get-release-version/action.yml
+++ b/get-release-version/action.yml
@@ -1,0 +1,29 @@
+name: "Get GitHub Latest Release Version"
+inputs:
+  repository:
+    description: 'This is the repository that we get the latest release version from'
+    required: true
+outputs:
+  version:
+    description: 'GitHub Latest Release version from specified repository'
+    value: ${{ steps.get-release.outputs.version }}
+runs:
+  using: "composite"
+  steps:
+    - name: Check Runner OS
+      shell: bash
+      run: |
+        if ["$RUNNER_OS" != "Linux"]; then
+          echo "[!] This workflow only supports Linux runners"
+          exit 1
+        fi
+
+    - name: Get Latest Release Version
+      id: get-release
+      env:
+        REPOSITORY: ${{ inputs.repository }}
+      run: |
+        VERSION=$(
+          curl -sL https://api.github.com/repos/$REPOSITORY/releases/latest | jq -r ".tag_name[1:]"
+        )
+        echo "::set-output name=version::$VERSION"


### PR DESCRIPTION
This PR adds an action that gets the latest GitHub release version from the specified repository.