### PR TITLE
Fix Version Bump Action

### DIFF
--- a/version-bump/main.py
+++ b/version-bump/main.py
@@ -44,7 +44,7 @@ def update_xml(version, file):
         ET.register_namespace("tools", "http://schemas.android.com/tools")
         mytree.write(file, encoding="utf-8", xml_declaration=True, pretty_print=True)
     # Microsoft .NET project files
-    elif "Microsoft.NET.Sdk.Web" in myroot.attrib["Sdk"]:
+    elif "Microsoft.NET.Sdk" in myroot.attrib["Sdk"]:
         version_property = [x for x in myroot[0] if x.tag == "Version"][-1]
         version_property.text = version
         mytree.write(file)


### PR DESCRIPTION
This PR switches the `Sdk` value that is looked for in .NET project files from `Microsoft.NET.Sdk.Web` to `Microsoft.NET.Sdk`.  This handles `csproj` files that don't use the `Web` part of the SDK.  This has been tested with projects that use the`Web` SDK and it still works.