### PR TITLE
Add Rebrandly action

### DIFF
--- a/update-rebrandly-link/README.md
+++ b/update-rebrandly-link/README.md
@@ -1,0 +1,17 @@
+# Update Rebrandly Link Action
+
+This action is for updating Rebrandly links.  It was designed exclusively for our new `self-host` repository workflows
+to update our Rebrandly links to point to the latest released verions of the `bitwarden.ps1/bitwarden.sh` and
+`run.ps1/run.sh` scripts.  It works by finding the `id` of the Rebrandly link by using the provided `domain` and
+`slashtag` parameters.  After it finds the `id`, it uses that to update the destination of that link to the provided
+`destination`.
+
+## Parameters
+
+`apikey`: We have this stored in our Production KeyVault.
+
+`domain`: This is the domain name of the link we have in Rebrandly. (ex: `go.btwrden.co`)
+
+`slashtag`: This is the slashtag of the link we have in Rebrandly. (ex: `bw-ps`)
+
+`destination`: This is the URL that the link in Rebrandly should point to.

--- a/update-rebrandly-link/action.yml
+++ b/update-rebrandly-link/action.yml
@@ -1,0 +1,56 @@
+name: "Update Rebrandly Link"
+inputs:
+  apikey:
+    description: 'API Key to access Rebrandly'
+    required: true
+  domain:
+    description: 'Domain name used for link'
+    required: true
+  slashtag:
+    description: 'Slashtag value for link'
+    required: true
+  destination:
+    description: 'New destination for link'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Check Runner OS
+      shell: bash
+      run: |
+        if ["$RUNNER_OS" != "Linux"]; then
+          echo "[!] This workflow only supports Linux runners"
+          exit 1
+        fi
+
+    - name: Get Link ID
+      id: get-link-id
+      shell: bash
+      env:
+        APIKEY: ${{ inputs.apikey }}
+        DOMAIN: ${{ inputs.domain }}
+        SLASHTAG: ${{ inputs.slashtag }}
+      run: |
+        ID=$(curl --request GET \
+          --url "https://api.rebrandly.com/v1/links?domain.fullName=$DOMAIN&slashtag=$SLASHTAG" \
+          --header "Accept: application/json" \
+          --header "apikey: $APIKEY" | jq '.[0].id')
+        echo "::set-output name=id::$ID"
+
+    - name: Update Link Destination
+      shell: bash
+      env:
+        APIKEY: ${{ inputs.apikey }}
+        ID: ${{ steps.get-link-id.outputs.id }}
+        DESTINATION: ${{ inputs.destination }}
+      run: |
+        curl --request POST \
+          --url https://api.rebrandly.com/v1/links/$ID \
+          --header "Accept: application/json" \
+          --header "Content-Type: application/json" \
+          --header "apikey: $APIKEY" \
+          --data "
+          {
+            'destination': '$DESTINATION'
+          }
+          "


### PR DESCRIPTION
This PR adds the `update-rebrandly-link` action for use in our new `self-host` repository workflows.