### PR TITLE
BEEEP: Add GHA version checker to linter

### DIFF
--- a/lint-workflow/lint.py
+++ b/lint-workflow/lint.py
@@ -4,28 +4,35 @@ import yaml
 import json
 import urllib3 as urllib
 
+
 def get_action_update(action_id):
     """
-        Takes and action id (bitwarden/gh-actions/version-bump@03ad9a873c39cdc95dd8d77dbbda67f84db43945)
-        and checks the action repo for the newest version.
-        If there is a new version, return the url to the updated version.
+    Takes and action id (bitwarden/gh-actions/version-bump@03ad9a873c39cdc95dd8d77dbbda67f84db43945)
+    and checks the action repo for the newest version.
+    If there is a new version, return the url to the updated version.
     """
 
     path, *hash = action_id.split("@")
     http = urllib.PoolManager()
     headers = {}
 
-    if os.getenv('GITHUB_PAT', None):
+    if os.getenv("GITHUB_PAT", None):
         headers["Authorization"] = f"Token {os.environ['GITHUB_PAT']}"
 
     if "bitwarden" in path:
         return None
 
-    r = http.request('GET', f"https://api.github.com/repos/{path}/releases/latest", headers=headers)
-    tag_name = json.loads(r.data)['tag_name']
-    r = http.request('GET', f"https://api.github.com/repos/{path}/git/ref/tags/{tag_name}", headers=headers)
-    updated_action = json.loads(r.data)['object']['sha']
-    
+    r = http.request(
+        "GET", f"https://api.github.com/repos/{path}/releases/latest", headers=headers
+    )
+    tag_name = json.loads(r.data)["tag_name"]
+    r = http.request(
+        "GET",
+        f"https://api.github.com/repos/{path}/git/ref/tags/{tag_name}",
+        headers=headers,
+    )
+    updated_action = json.loads(r.data)["object"]["sha"]
+
     if updated_action not in hash:
         return f"https://github.com/{path}/commit/{updated_action}"
 
@@ -121,10 +128,10 @@ def lint(filename):
                             findings.append(
                                 f"- Step {str(i)} of job key '{job_key}' uses an outdated action, consider updating it '{update_available}'."
                             )
-                        
+
                     # If the step has a 'run' key and only has one command, check if it's a single line.
                     if "run" in step:
-                        if step["run"].count('\n') == 1:
+                        if step["run"].count("\n") == 1:
                             findings.append(
                                 f"- Run in step {str(i)} of job key '{job_key}' should be a single line."
                             )

--- a/lint-workflow/lint.py
+++ b/lint-workflow/lint.py
@@ -16,8 +16,8 @@ def get_action_update(action_id):
     http = urllib.PoolManager()
     headers = {}
 
-    if os.getenv("GITHUB_PAT", None):
-        headers["Authorization"] = f"Token {os.environ['GITHUB_PAT']}"
+    if os.getenv("GITHUB_TOKEN", None):
+        headers["Authorization"] = f"Token {os.environ['GITHUB_TOKEN']}"
 
     if "bitwarden" in path:
         path_list = path.split("/", 2)


### PR DESCRIPTION
Adds a way for the linter to check if there is a version update to any public AND Bitwarden Github actions. When there is an update available, it will append a message to the linter output with a link to the newest version. This will allow the engineer to review the update before decided to use it.

Example:
![image](https://user-images.githubusercontent.com/77340197/149587407-b86afb43-0879-476e-8210-3df429337460.png)
