### PR TITLE
Update Version Bump action for Helm charts

### DIFF
--- a/version-bump/Dockerfile
+++ b/version-bump/Dockerfile
@@ -5,6 +5,7 @@ ADD . /app
 WORKDIR /app
 
 RUN pip3 install lxml --target=/app
+RUN pip3 install pyyaml --target=/app
 
 ENV PYTHONPATH /app
 

--- a/version-bump/README.md
+++ b/version-bump/README.md
@@ -1,6 +1,7 @@
 # Version Bump Action
 
-A Github Action that will replace versions in JSON, PLIST, and XML files. Specifically created for interacting with AndroidManifest, iOS development plists, and Node package JSON files.
+A Github Action that will replace versions in JSON, PLIST, YAML, and XML files.
+Specifically created for interacting with AndroidManifest, iOS development plists, Helm Charts, and Node package JSON files.
 
 ## Usage
 

--- a/version-bump/main.py
+++ b/version-bump/main.py
@@ -2,7 +2,6 @@ import os
 import json
 import plistlib
 import re
-from unittest import loader
 import lxml.etree as ET
 import yaml
 

--- a/version-bump/main.py
+++ b/version-bump/main.py
@@ -30,7 +30,7 @@ def update_json(version, file_path):
 
 
 def update_plist(version, file_path):
-    with open(file, "rb") as plist:
+    with open(file_path, "rb") as plist:
 
         pl = plistlib.load(plist)
         pl["CFBundleShortVersionString"] = version

--- a/version-bump/main.py
+++ b/version-bump/main.py
@@ -2,6 +2,7 @@ import os
 import json
 import plistlib
 import re
+from unittest import loader
 import lxml.etree as ET
 import yaml
 
@@ -71,7 +72,7 @@ def update_xml(version, file):
 # For updating Helm Charts - Chart.yaml version
 def update_yaml(version, file):
     with open(file, "r") as f:
-        doc = yaml.load(f)
+        doc = yaml.load(f, Loader=yaml.FullLoader)
 
     doc["version"] = version
 

--- a/version-bump/main.py
+++ b/version-bump/main.py
@@ -17,37 +17,37 @@ def get_file_name(file_path):
     return file_name
 
 
-def update_json(version, file):
-    with open(file) as json_file:
+def update_json(version, file_path):
+    with open(file_path) as json_file:
         data = json.load(json_file)
         data["version"] = version
         try:
             data["packages"][""]["version"] = version
         except KeyError:
             pass
-        json.dump(data, open(file, "w"), indent=2)
-    with open(file, "a") as f:
+        json.dump(data, open(file_path, "w"), indent=2)
+    with open(file_path, "a") as f:
         f.write("\n")  # Make sure we add the new line back in at EOF.
 
 
-def update_plist(version, file):
+def update_plist(version, file_path):
     with open(file, "rb") as plist:
 
         pl = plistlib.load(plist)
         pl["CFBundleShortVersionString"] = version
 
         data = pl
-    with open(file, "wb") as update_plist:
+    with open(file_path, "wb") as update_plist:
         plistlib.dump(data, update_plist, sort_keys=False)
 
 
-def update_xml(version, file):
-    mytree = ET.parse(file)
+def update_xml(version, file_path):
+    mytree = ET.parse(file_path)
     myroot = mytree.getroot()
 
     # Android Manifests
     if myroot.tag == "manifest":
-        with open(file, "r") as f:
+        with open(file_path, "r") as f:
             data = f.read()
             data_new = re.sub(
                 'android:versionName="[0-9]+\.[0-9]+\.[0-9]+"',
@@ -55,28 +55,28 @@ def update_xml(version, file):
                 data,
                 flags=re.M,
             )
-        with open(file, "w") as f:
+        with open(file_path, "w") as f:
             f.write(data_new)
 
     # Microsoft .NET project files
     elif myroot.attrib.has_key("Sdk") and "Microsoft.NET.Sdk" in myroot.attrib["Sdk"]:
         version_property = [x for x in myroot[0] if x.tag == "Version"][-1]
         version_property.text = version
-        mytree.write(file)
+        mytree.write(file_path)
     # MSBuild Props
     else:
         myroot[0][1].text = version
-        mytree.write(file, encoding="utf-8")
+        mytree.write(file_path, encoding="utf-8")
 
 
 # For updating Helm Charts - Chart.yaml version
-def update_yaml(version, file):
-    with open(file, "r") as f:
+def update_yaml(version, file_path):
+    with open(file_path, "r") as f:
         doc = yaml.load(f, Loader=yaml.FullLoader)
 
     doc["version"] = version
 
-    with open(file, "w") as f:
+    with open(file_path, "w") as f:
         yaml.dump(doc, f)
 
 

--- a/version-bump/main.py
+++ b/version-bump/main.py
@@ -2,7 +2,6 @@ import os
 import json
 import plistlib
 import re
-from stat import FILE_ATTRIBUTE_NO_SCRUB_DATA
 import lxml.etree as ET
 import yaml
 


### PR DESCRIPTION
This PR introduces functionality to the `version-bump` action so that it can bump Helm charts `Chart.yaml` files.