### PR TITLE
call-workflow support added

### DIFF
--- a/lint-workflow/lint.py
+++ b/lint-workflow/lint.py
@@ -80,7 +80,7 @@ def lint(filename):
                 job = jobs[job_key]
 
                 # Make sure runner is using pinned version.
-                runner = job["runs-on"]
+                runner = job.get("runs-on", "")
                 if "-latest" in runner:
                     findings.append(
                         f"- Runner version is set to '{runner}', but needs to be pinned to a version."
@@ -104,7 +104,7 @@ def lint(filename):
                             )
 
                 # Loop through steps in job.
-                steps = job["steps"]
+                steps = job.get("steps", "")
                 for i, step in enumerate(steps, start=1):
                     # Check for 'name' key for step.
                     if "name" not in step:

--- a/lint-workflow/tests/test.yml
+++ b/lint-workflow/tests/test.yml
@@ -6,12 +6,22 @@ on:
     inputs: {}
 
 jobs:
-  download-latest:
+  call-workflow:
+    uses: bitwarden/server/.github/workflows/workflow-linter.yml@master
+
+  test-normal-action:
     name: Download Latest
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78bde5606d7042f
 
       - run: |
           echo test
+
+  test-local-action:
+    name: Testing a local action call
+    runs-on: ubuntu-20.04
+    steps:
+      - name: local-action
+        uses: ./version-bump

--- a/lint-workflow/tests/test_lint.py
+++ b/lint-workflow/tests/test_lint.py
@@ -4,5 +4,5 @@ def test_lint(capfd):
     file_path = "test.yml"
     lint_output = lint(file_path)
     out, err = capfd.readouterr()
-    assert "Step 1 of job key 'download-latest' uses an outdated action, consider updating it" in out
-    assert "Run in step 2 of job key 'download-latest' should be a single line." in out
+    assert "Step 1 of job key 'test-normal-action' uses an outdated action, consider updating it" in out
+    assert "Run in step 2 of job key 'test-normal-action' should be a single line." in out


### PR DESCRIPTION
As I am trying to reduce duplication and a lot of copy and pasting. I want to use reusable workflows for the linter. This will allow us to store the linter workflow in a single public repo and call it from other repositories. Due to the nature of `call-workflow`, the linter fails because of missing keys. I updated the linter to handle missing keys and default to an empty string. This allows tests to pass and `call-workflow` jobs to still be properly validated. 

* Used .get() to except workflows that don't need certain values, defaulting to ""
* Adds call-workflow to test.yml workflow for tests
* Updated wording in test to reflect changes in test.yml