### PR TITLE
Add functionality for passing multiple files into linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/launch.json
 .vscode/settings.json
+**/__pycache__/

--- a/lint-workflow/action.yml
+++ b/lint-workflow/action.yml
@@ -11,5 +11,7 @@ runs:
       shell: bash
     - run: python ${{ github.action_path }}/lint.py "${{ inputs.workflows }}"
       shell: bash
-    - run: yamllint -f colored -c ${{ github.action_path }}/.yamllint.yml "${{ inputs.workflows }}"
+    - run: |
+        TRIM_PATH=$(echo ${{ inputs.workflows }} | | tr '\n' ' ')
+        yamllint -f colored -c ${{ github.action_path }}/.yamllint.yml "$TRIM_PATH"
       shell: bash

--- a/lint-workflow/action.yml
+++ b/lint-workflow/action.yml
@@ -1,11 +1,15 @@
 name: 'Lint Workflow'
 description: 'Lints GitHub Actions Workflow'
+inputs:
+  workflows:
+    description: "Path to workflow file(s)"
+    required: true
 runs:
   using: "composite"
   steps:
     - run: pip install --user yamllint
       shell: bash
-    - run: python ${{ github.action_path }}/lint.py .github/workflows
+    - run: python ${{ github.action_path }}/lint.py "${{ inputs.workflows }}"
       shell: bash
-    - run: yamllint -f colored -c ${{ github.action_path }}/.yamllint.yml .github/workflows
+    - run: yamllint -f colored -c ${{ github.action_path }}/.yamllint.yml "${{ inputs.workflows }}"
       shell: bash

--- a/lint-workflow/action.yml
+++ b/lint-workflow/action.yml
@@ -13,6 +13,6 @@ runs:
       shell: bash
     - run: |
         TRIM_PATH=$(echo ${{ inputs.workflows }} | tr '\n' ' ')
-        yamllint -f colored -c ${{ github.action_path }}/.yamllint.yml "$TRIM_PATH"
+        yamllint -f colored -c ${{ github.action_path }}/.yamllint.yml $TRIM_PATH
       shell: bash
       working-directory: ${{ github.workspace }}

--- a/lint-workflow/action.yml
+++ b/lint-workflow/action.yml
@@ -12,6 +12,6 @@ runs:
     - run: python ${{ github.action_path }}/lint.py "${{ inputs.workflows }}"
       shell: bash
     - run: |
-        TRIM_PATH=$(echo ${{ inputs.workflows }} | | tr '\n' ' ')
+        TRIM_PATH=$(echo ${{ inputs.workflows }} | tr '\n' ' ')
         yamllint -f colored -c ${{ github.action_path }}/.yamllint.yml "$TRIM_PATH"
       shell: bash

--- a/lint-workflow/action.yml
+++ b/lint-workflow/action.yml
@@ -12,6 +12,6 @@ runs:
     - run: python ${{ github.action_path }}/lint.py "${{ inputs.workflows }}"
       shell: bash
     - run: |
-        TRIM_PATH=$(echo ${{ inputs.workflows }} | tr '\n' ' ')
+        TRIM_PATH=$(echo ${{ inputs.workflows }} | tr '\n' ' ' | awk '{$1=$1;print}')
         yamllint -f colored -c ${{ github.action_path }}/.yamllint.yml "$TRIM_PATH"
       shell: bash

--- a/lint-workflow/action.yml
+++ b/lint-workflow/action.yml
@@ -15,3 +15,4 @@ runs:
         TRIM_PATH=$(echo ${{ inputs.workflows }} | tr '\n' ' ' | awk '{$1=$1;print}')
         yamllint -f colored -c ${{ github.action_path }}/.yamllint.yml "$TRIM_PATH"
       shell: bash
+      working-directory: ${{ github.workspace }}

--- a/lint-workflow/action.yml
+++ b/lint-workflow/action.yml
@@ -12,7 +12,7 @@ runs:
     - run: python ${{ github.action_path }}/lint.py "${{ inputs.workflows }}"
       shell: bash
     - run: |
-        TRIM_PATH=$(echo ${{ inputs.workflows }} | tr '\n' ' ' | awk '{$1=$1;print}')
+        TRIM_PATH=$(echo ${{ inputs.workflows }} | tr '\n' ' ')
         yamllint -f colored -c ${{ github.action_path }}/.yamllint.yml "$TRIM_PATH"
       shell: bash
       working-directory: ${{ github.workspace }}

--- a/lint-workflow/lint.py
+++ b/lint-workflow/lint.py
@@ -7,7 +7,7 @@ import urllib3 as urllib
 
 def get_action_update(action_id):
     """
-    Takes and action id (bitwarden/gh-actions/version-bump@03ad9a873c39cdc95dd8d77dbbda67f84db43945)
+    Takes in an action id (bitwarden/gh-actions/version-bump@03ad9a873c39cdc95dd8d77dbbda67f84db43945)
     and checks the action repo for the newest version.
     If there is a new version, return the url to the updated version.
     """
@@ -180,6 +180,10 @@ def main():
     # Check if argument is file, then append to input files.
     if os.path.isfile(args.input):
         input_files.append(args.input)
+    # Check if argument contains multiple files.
+    elif len(args.input.split()) > 1:
+        for file in args.input.split():
+            input_files.append(file)
     # Check if argument is directory, then recursively add all *.yml and *.yaml files to input files.
     elif os.path.isdir(args.input):
         for subdir, dirs, files in os.walk(args.input):
@@ -189,7 +193,7 @@ def main():
                 if filepath.endswith(".yml") or filepath.endswith(".yaml"):
                     input_files.append(filepath)
     else:
-        print("File/Directory does not exist, exiting.")
+        print("File(s)/Directory does not exist, exiting.")
 
     for filename in input_files:
         lint(filename)

--- a/lint-workflow/lint.py
+++ b/lint-workflow/lint.py
@@ -1,3 +1,4 @@
+import sys
 import argparse
 import os
 import yaml
@@ -167,12 +168,16 @@ def lint(filename):
         print()
 
 
-def main():
+def main(args=None):
+
+    # Pull the arguments from the command line
+    if not args:
+        args = sys.argv[1:]
 
     # Read arguments from command line.
     parser = argparse.ArgumentParser()
     parser.add_argument("input", help="file or directory input")
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
     # Set up list for files to lint.
     input_files = []
@@ -182,8 +187,7 @@ def main():
         input_files.append(args.input)
     # Check if argument contains multiple files.
     elif len(args.input.split()) > 1:
-        for file in args.input.split():
-            input_files.append(file)
+        input_files.extend(args.input.split())
     # Check if argument is directory, then recursively add all *.yml and *.yaml files to input files.
     elif os.path.isdir(args.input):
         for subdir, dirs, files in os.walk(args.input):

--- a/lint-workflow/lint.py
+++ b/lint-workflow/lint.py
@@ -168,16 +168,16 @@ def lint(filename):
         print()
 
 
-def main(args=None):
+def main(input_args=None):
 
     # Pull the arguments from the command line
-    if not args:
-        args = sys.argv[1:]
+    if not input_args:
+        input_args = sys.argv[1:]
 
     # Read arguments from command line.
     parser = argparse.ArgumentParser()
     parser.add_argument("input", help="file or directory input")
-    args = parser.parse_args(args)
+    args = parser.parse_args(input_args)
 
     # Set up list for files to lint.
     input_files = []

--- a/lint-workflow/tests/test-alt.yml
+++ b/lint-workflow/tests/test-alt.yml
@@ -1,0 +1,25 @@
+---
+name: Lint Test File, DO NOT USE
+
+on:
+  workflow_dispatch:
+    inputs: {}
+
+jobs:
+
+  test-normal-action:
+    name: Download Latest
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78bde5606d7042f
+
+      - run: |
+          echo test
+
+  test-local-action:
+    name: Testing a local action call
+    runs-on: ubuntu-20.04
+    steps:
+      - name: local-action
+        uses: ./version-bump

--- a/lint-workflow/tests/test_a.yaml
+++ b/lint-workflow/tests/test_a.yaml
@@ -1,0 +1,27 @@
+---
+name: Lint Test File, DO NOT USE
+
+on:
+  workflow_dispatch:
+    inputs: {}
+
+jobs:
+  call-workflow:
+    uses: bitwarden/server/.github/workflows/workflow-linter.yml@master
+
+  test-normal-action:
+    name: Download Latest
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78bde5606d7042f
+
+      - run: |
+          echo test
+
+  test-local-action:
+    name: Testing a local action call
+    runs-on: ubuntu-20.04
+    steps:
+      - name: local-action
+        uses: ./version-bump

--- a/lint-workflow/tests/test_action_update.py
+++ b/lint-workflow/tests/test_action_update.py
@@ -5,7 +5,7 @@ http = urllib.PoolManager()
 
 
 def test_action_update():
-    action_id = 'actions/checkout@86f86b36ef15e6570752e7175f451a512eac206b'
+    action_id = "actions/checkout@86f86b36ef15e6570752e7175f451a512eac206b"
     sub_string = "github.com"
     update_url = get_action_update(action_id)
     assert str(sub_string) in str(update_url)

--- a/lint-workflow/tests/test_lint.py
+++ b/lint-workflow/tests/test_lint.py
@@ -5,7 +5,6 @@ def test_lint(capfd):
     file_path = "test.yml"
     lint_output = lint(file_path)
     out, err = capfd.readouterr()
-    print(out)
     assert (
         "\x1b[33mwarning\x1b[0m Name value for workflow is not capitalized. [crowdin Pull]"
         in out

--- a/lint-workflow/tests/test_lint.py
+++ b/lint-workflow/tests/test_lint.py
@@ -1,8 +1,14 @@
 from lint import lint
 
+
 def test_lint(capfd):
     file_path = "test.yml"
     lint_output = lint(file_path)
     out, err = capfd.readouterr()
-    assert "Step 1 of job key 'test-normal-action' uses an outdated action, consider updating it" in out
-    assert "Run in step 2 of job key 'test-normal-action' should be a single line." in out
+    assert (
+        "Step 1 of job key 'test-normal-action' uses an outdated action, consider updating it"
+        in out
+    )
+    assert (
+        "Run in step 2 of job key 'test-normal-action' should be a single line." in out
+    )

--- a/lint-workflow/tests/test_main.py
+++ b/lint-workflow/tests/test_main.py
@@ -1,5 +1,7 @@
 from lint import main
 
+# Tests for argparse inputs and outputs using capsys.readouterr()
+
 
 def test_main_single_file(capsys):
     main(["test.yml"])
@@ -26,9 +28,31 @@ def test_main_folder(capsys):
     assert "test-alt.yml" in result
 
 
+def test_main_folder_and_files(capsys):
+    main(["test.yml ./"])
+    captured = capsys.readouterr()
+    result = captured.out
+    print(result)
+
+
 def test_main_not_found(capsys):
+    # File that doesn't exist
     main(["not-a-real-file.yml"])
     captured = capsys.readouterr()
     result = captured.out
     assert isinstance(result, str)
-    assert "File(s)/Directory does not exist, exiting." in result
+    assert (
+        'File(s)/Directory: "not-a-real-file.yml"  does not exist, exiting.' in result
+    )
+    # Empty string
+    main([""])
+    captured = capsys.readouterr()
+    result = captured.out
+    assert isinstance(result, str)
+    assert 'File(s)/Directory: ""  does not exist, exiting.' in result
+    # Spaces in string
+    main(["  "])
+    captured = capsys.readouterr()
+    result = captured.out
+    assert isinstance(result, str)
+    assert 'File(s)/Directory: "  "  does not exist, exiting.' in result

--- a/lint-workflow/tests/test_main.py
+++ b/lint-workflow/tests/test_main.py
@@ -1,0 +1,30 @@
+from lint import main
+
+def test_main_single_file(capsys):
+    main(["test.yml"])
+    captured = capsys.readouterr()
+    result = captured.out
+    assert "test.yml" in result
+
+def test_main_multiple_files(capsys):
+    main(["test.yml test-alt.yml"])
+    captured = capsys.readouterr()
+    result = captured.out
+    assert isinstance(result, str)
+    assert "test.yml" in result
+    assert "test-alt.yml" in result
+
+def test_main_folder(capsys):
+    main(["./"])
+    captured = capsys.readouterr()
+    result = captured.out
+    assert isinstance(result, str)
+    assert "test.yml" in result
+    assert "test-alt.yml" in result
+
+def test_main_not_found(capsys):
+    main(["not-a-real-file.yml"])
+    captured = capsys.readouterr()
+    result = captured.out
+    assert isinstance(result, str)
+    assert "File(s)/Directory does not exist, exiting." in result

--- a/lint-workflow/tests/test_main.py
+++ b/lint-workflow/tests/test_main.py
@@ -1,10 +1,12 @@
 from lint import main
 
+
 def test_main_single_file(capsys):
     main(["test.yml"])
     captured = capsys.readouterr()
     result = captured.out
     assert "test.yml" in result
+
 
 def test_main_multiple_files(capsys):
     main(["test.yml test-alt.yml"])
@@ -14,6 +16,7 @@ def test_main_multiple_files(capsys):
     assert "test.yml" in result
     assert "test-alt.yml" in result
 
+
 def test_main_folder(capsys):
     main(["./"])
     captured = capsys.readouterr()
@@ -21,6 +24,7 @@ def test_main_folder(capsys):
     assert isinstance(result, str)
     assert "test.yml" in result
     assert "test-alt.yml" in result
+
 
 def test_main_not_found(capsys):
     main(["not-a-real-file.yml"])

--- a/lint-workflow/tests/test_workflow_files.py
+++ b/lint-workflow/tests/test_workflow_files.py
@@ -1,0 +1,16 @@
+from lint import workflow_files
+
+
+def test_workflow_files():
+    assert workflow_files("") == []
+    assert workflow_files("test.yml") == ["test.yml"]
+    assert workflow_files("test.yml test-alt.yml") == sorted(
+        ["test.yml", "test-alt.yml"]
+    )
+    assert workflow_files("../tests") == sorted(
+        ["../tests/test.yml", "../tests/test-alt.yml", "../tests/test_a.yaml"]
+    )
+    assert workflow_files("test.yml ./") == sorted(
+        [".//test-alt.yml", ".//test.yml", ".//test_a.yaml", "test.yml"]
+    )
+    assert workflow_files("not-a-real-file.yml") == []

--- a/lint-workflow/tests/test_workflow_files.py
+++ b/lint-workflow/tests/test_workflow_files.py
@@ -1,16 +1,20 @@
+import os
 from lint import workflow_files
 
 
 def test_workflow_files():
     assert workflow_files("") == []
+    assert workflow_files("not-a-real-file.yml") == []
     assert workflow_files("test.yml") == ["test.yml"]
+    # multiple files
     assert workflow_files("test.yml test-alt.yml") == sorted(
         ["test.yml", "test-alt.yml"]
     )
-    assert workflow_files("../tests") == sorted(
-        ["../tests/test.yml", "../tests/test-alt.yml", "../tests/test_a.yaml"]
-    )
-    assert workflow_files("test.yml ./") == sorted(
-        [".//test-alt.yml", ".//test.yml", ".//test_a.yaml", "test.yml"]
-    )
-    assert workflow_files("not-a-real-file.yml") == []
+    # directory
+    assert workflow_files("../tests") == sorted(set(
+        ["../tests/"+file for file in os.listdir("../tests") if file.endswith((".yml", ".yaml"))]
+    ))
+    # directory and files   
+    assert workflow_files("test.yml ../tests") == sorted(set(
+        ["test.yml"] + ["../tests/"+file for file in os.listdir("./") if file.endswith((".yml", ".yaml"))]
+    ))


### PR DESCRIPTION
# Objective
Improve performance and reduce API overages by only linting workflows that have been changed. 

Test run here: https://github.com/bitwarden/gh-actions/runs/6730350212?check_suite_focus=true

## Changes
`.gitignore`: 
  - Added pytest folders

`lint-workflow/action.yml`: 
  - Added an input for workflows(s) to be linted
  - Updated yamllint to support multiple files
`lint-workflow/lint.py`:
  - Adds an `input_args` parameter to the `main()` function. Allowing the function to be tested easier
  - Added workflow_files() function and moves much of the `os` methods into it
  - workflow_files() checks the input and finds workflows in any directories
  - Spelling changes
  - Added `401` check for get_github_api_response()
  - Updated formatting
  - Adds a `break` for workflows that use local actions
  - Restructures logic at end of file to use new function
  - Updated output if files aren't found

`lint-workflow/tests/test_main.py`:
  - Test multiple folders and files through the CLI

`lint-workflow/tests/test_workflow_files.py`:
  - Test multiple folders and files for the `workflow_files()` function
