### PR TITLE
Removing leading zero constraint on the dotnet version check

### DIFF
--- a/release-version-check/action.yml
+++ b/release-version-check/action.yml
@@ -85,7 +85,7 @@ runs:
             version=$( jq -r ".version" ${{ inputs.file }} )
             ;;
           "dotnet")
-            version=$( grep -o "<Version>.*</Version>" ${{ inputs.file }} | grep -Eo "[0-9]{4}\.[0-9]{2}\.[0-9]+" )
+            version=$( grep -o "<Version>.*</Version>" ${{ inputs.file }} | grep -Eo "[0-9]{4}\.[0-9]+\.[0-9]+" )
             ;;
           "xamarin")
             version=$(sed -E -n '/^<manifest/s/^.*[ ]android:versionName="([^"]+)".*$/\1/p' ${{ inputs.file }} | tr -d '"')


### PR DESCRIPTION
# Objective

Update version convention in dotnet projects to `YYYY.M.R` (no leading zero in the month portion).