### PR TITLE
BEEEP - Update lint-workflow action

### DIFF
--- a/.github/workflows/workflow-linter.yml
+++ b/.github/workflows/workflow-linter.yml
@@ -13,10 +13,14 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
 
-      - name: Checkout Version Branch
+      - name: Checkout Full History
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          fetch-depth: 0
 
       - name: Workflow Lint
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: bitwarden/gh-actions/lint-workflow@676ae4100b19625c0b0b70525e6c0181bd2d405f
+        uses: bitwarden/gh-actions/lint-workflow@7bdcb9d0dbd4851a7225319fb962fa7bdd45bba9
+        with:
+          workflows: $(git diff --name-only ${{ github.event.before }}..${{ github.event.after }})


### PR DESCRIPTION
Updates the workflow linter action to include 
- Linting only changed workflows
- GitHub API retries
- Exit codes

More information on changes:
https://github.com/bitwarden/gh-actions/pull/51
https://github.com/bitwarden/gh-actions/pull/54
https://github.com/bitwarden/gh-actions/pull/49