### PR TITLE
Update deprecated Azure Key Vault in workflows

### DIFF
--- a/lint-workflow/tests/test.yml
+++ b/lint-workflow/tests/test.yml
@@ -24,10 +24,17 @@ jobs:
 
       - name: Retrieve secrets
         id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
-        with:
-          keyvault: "bitwarden-prod-kv"
-          secrets: "crowdin-api-token"
+        env:
+          KEYVAULT: bitwarden-prod-kv
+          SECRETS: |
+            crowdin-api-token
+        run: |
+          for i in ${SECRETS//,/ }
+          do
+            VALUE=$(az keyvault secret show --vault-name $KEYVAULT --name $i --query value --output tsv)
+            echo "::add-mask::$VALUE"
+            echo "::set-output name=$i::$VALUE"
+          done
 
       - name: Download translations
         uses: crowdin/github-action@e39093fd75daae7859c68eded4b43d42ec78d8ea  # v1.3.2

--- a/setup-docker-trust/action.yml
+++ b/setup-docker-trust/action.yml
@@ -27,13 +27,20 @@ runs:
 
     - name: Retrieve secrets
       id: get-secrets
-      uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
-      with:
-        keyvault: ${{ inputs.azure-keyvault-name }}
-        secrets: "docker-password,
-                  docker-username,
-                  dct-delegate-repo-passphrase,
-                  dct-delegate-key"
+      env:
+        KEYVAULT: ${{ inputs.azure-keyvault-name }}
+        SECRETS: |
+          docker-password,
+          docker-username,
+          dct-delegate-repo-passphrase,
+          dct-delegate-key
+      run: |
+        for i in ${SECRETS//,/ }
+        do
+          VALUE=$(az keyvault secret show --vault-name $KEYVAULT --name $i --query value --output tsv)
+          echo "::add-mask::$VALUE"
+          echo "::set-output name=$i::$VALUE"
+        done
 
     - name: Log into Docker
       shell: bash


### PR DESCRIPTION
The GitHub action Azure Key Vault is being deprecated and will no longer be maintained. The outcome of the related spike offers a solution to implement as a drop-in replacement using bash and the Az CLI. All references for the `Azure/get-keyvault-secrets` action will need to be replaced with this bash step in all our workflows.