### PR TITLE
update ::set-output to latest

### DIFF
--- a/.github/workflows/test-release-version-check.yml
+++ b/.github/workflows/test-release-version-check.yml
@@ -77,7 +77,7 @@ jobs:
         id: set-status
         run: |
           echo "Status Status - ${{ matrix.name }}: ${{ steps.run-version-check.outputs.status }}"
-          echo "::set-output name=${{ matrix.name }}::${{ steps.run-version-check.outputs.status }}"
+          echo "${{ matrix.name }}=${{ steps.run-version-check.outputs.status }}" >> $GITHUB_OUTPUT
 
 
   run-version-check-test:


### PR DESCRIPTION
## Objective

This PR is updating the set output command in the workflow to the latest method, the previous is deprecated.
Changes Job steps with one line of code but taking two lines to one line.

## Code changes
Change the ::set-output command to Github's environment variable $GITHUB_OUTPUT

* **file.ext:** Description of what was changed and why
- .github/workflows/*.yaml files
