### PR TITLE
Update output method for Version Bump action

### DIFF
--- a/version-bump/main.py
+++ b/version-bump/main.py
@@ -105,4 +105,4 @@ if __name__ == "__main__":
     else:
         raise Exception("No file was recognized as a supported format.")
 
-    print(f"::set-output name=status::Updated {file_path}")
+    print(f"status=Updated {file_path} >> $GITHUB_OUTPUT")

--- a/version-bump/main.py
+++ b/version-bump/main.py
@@ -105,4 +105,4 @@ if __name__ == "__main__":
     else:
         raise Exception("No file was recognized as a supported format.")
 
-    print(f"status=Updated {file_path} >> $GITHUB_OUTPUT")
+    os.environ["GITHUB_OUTPUT"] += f"status=Updated {file_path}"

--- a/version-bump/main.py
+++ b/version-bump/main.py
@@ -105,4 +105,7 @@ if __name__ == "__main__":
     else:
         raise Exception("No file was recognized as a supported format.")
 
-    os.environ["GITHUB_OUTPUT"] += f"status=Updated {file_path}"
+    if "GITHUB_OUTPUT" in os.environ:
+        with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+            print("{0}={1}".format("status", f"Updated {file_path}"), file=f)
+


### PR DESCRIPTION
This PR updates the output method for the `Version Bump` action to no longer use `set-output` which has been deprecated by GitHub.