### PR TITLE
Update setup-docker-trust action

### DIFF
--- a/setup-docker-trust/action.yml
+++ b/setup-docker-trust/action.yml
@@ -1,4 +1,5 @@
 name: "Setup Docker Trust"
+description: "Configures Docker Trust"
 inputs:
   azure-creds:
     description: 'Credentials for the Azure Subscription that contains the docker trust secrets'
@@ -21,13 +22,13 @@ runs:
         fi
 
     - name: Login to Azure
-      uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
+      uses: Azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2 # v1.4.7
       with:
         creds: ${{ inputs.azure-creds }}
 
     - name: Retrieve secrets
       id: get-secrets
-      uses: bitwarden/gh-actions/get-keyvault-secrets@34ecb67b2a357795dc893549df0795e7383ff50f
+      uses: bitwarden/gh-actions/get-keyvault-secrets@c86ced0dc8c9daeecf057a6333e6f318db9c5a2b
       with:
         keyvault: "${{ inputs.azure-keyvault-name }}"
         secrets: "docker-password,


### PR DESCRIPTION
This PR updates the action hashes in the `setup-docker-trust` action to resolve `set-output` warnings.