### PR TITLE
Update AST action to use dotnet 6

### DIFF
--- a/install-ast/action.yml
+++ b/install-ast/action.yml
@@ -13,14 +13,14 @@ runs:
         fi
 
     - name: Set up dotnet
-      uses: actions/setup-dotnet@4d4a70f4a5b2a5a5329f13be4ac933f2c9206ac0
+      uses: actions/setup-dotnet@9211491ffb35dd6a6657ca4f45d43dfe6e97c829 # v3.0.3
       with:
-        dotnet-version: "3.1.x"
+        dotnet-version: "6.0.x"
 
     - name: Install AST
       shell: pwsh
       env:
-        AST_PINNED_COMMIT: "ce87e84a58dff318f62ffe5177bf3e179d815108"
+        AST_PINNED_COMMIT: "9f30f7a267eff7f3fe494c49e5a536a337c8dfde" # v4.0.1
       run: |
         cd $HOME
 


### PR DESCRIPTION
Updates the AST action to use the newest version of AST (https://github.com/vcsjones/AzureSignTool/releases/tag/v4.0.1) and updates the action to set up dotnet 6.

I upgraded the `setup-dotnet` action to version `3.0.3` as well, and added comments where they would be helpful.