### PR TITLE
Fix workflow linter for bitwarden sm action

### DIFF
--- a/.github/workflows/workflow-linter.yml
+++ b/.github/workflows/workflow-linter.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Workflow Lint
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: bitwarden/gh-actions/lint-workflow@606d9e0c8e15d92c7cc0d87be24781627a1330cd
+        uses: bitwarden/gh-actions/lint-workflow@e5f3566df3a05cfa8c2d9af99bd74b08c6ddb98d
         with:
           workflows: ${{ steps.changed-workflows.outputs.modified-workflows }}
 

--- a/lint-workflow/lint.py
+++ b/lint-workflow/lint.py
@@ -97,7 +97,7 @@ def action_repo_exists(action_id):
 
     path, *hash = action_id.split("@")
 
-    if "bitwarden" in path:
+    if "bitwarden/gh-actions" in path:
         path_list = path.split("/", 2)
         url = f"https://api.github.com/repos/{path_list[0]}/{path_list[1]}"
         response = get_github_api_response(url, action_id)

--- a/lint-workflow/lint.py
+++ b/lint-workflow/lint.py
@@ -326,7 +326,7 @@ def lint(filename):
                         # If the step has a 'uses' key, check path for external workflow
                         path_list = path.split("/", 2)
 
-                        if "bitwarden" in path and len(path_list) < 3:
+                        if "bitwarden/gh-actions" in path and len(path_list) < 3:
                             findings.append(
                                 LintFinding(
                                     f"Step {str(i)} of job key '{job_key}' does not have a valid action path. (missing name of the repository or workflow)",

--- a/lint-workflow/lint.py
+++ b/lint-workflow/lint.py
@@ -152,7 +152,7 @@ def get_action_update(action_id):
     if path in memoized_action_update_urls:
         return memoized_action_update_urls[path]
     else:
-        if "bitwarden" in path:
+        if "bitwarden/gh-actions" in path:
             path_list = path.split("/", 2)
             url = f"https://api.github.com/repos/{path_list[0]}/{path_list[1]}/commits?path={path_list[2]}"
             response = get_github_api_response(url, action_id)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

Fix workflow linter to  be able to check `bitwarden/sm-action` as normal public gh action and not fail on it. 

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix
-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **lint-workflow/lint.py:** Add check for `bitwarden/gh-actions` instead of `bitwarden` to treat `bitwarden/sm-actrion` as any other public action.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
