### PR TITLE
Change linter comment rule for Renovate

### DIFF
--- a/lint-workflow/.yamllint.yml
+++ b/lint-workflow/.yamllint.yml
@@ -11,6 +11,8 @@ rules:
     level: warning
   commas:
     level: warning
+  comments:
+    min-spaces-from-content: 1
   empty-lines:
     level: warning
   hyphens:


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
All of the actions in our workflows that are updated by Renovate use a single space before comments.  The workflow linter rule has been updated to reflect that.

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🤖 Build/deploy pipeline (DevOps)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Update the workflow linter to stop producing warnings on single spaces before comments.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **lint-workflow/.yamllint.yml:** Update the `min-spaces-from-content` setting under the `comments` rule.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
