### PR TITLE
Fix for download-artifacts action

### DIFF
--- a/download-artifacts/main.js
+++ b/download-artifacts/main.js
@@ -24,7 +24,7 @@ async function main() {
         const token = core.getInput("github_token", { required: true })
         const [owner, repo] = core.getInput("repo", { required: true }).split("/")
         const path = core.getInput("path", { required: true })
-        const name = core.getInput("artifacts")
+        const names = core.getInput("artifacts") ? core.getInput("artifacts") : "*"
         const nameIsRegExp = core.getBooleanInput("name_is_regexp")
         const skipUnpack = core.getBooleanInput("skip_unpack")
         const ifNoArtifactFound = core.getInput("if_no_artifact_found")
@@ -44,7 +44,7 @@ async function main() {
         const client = github.getOctokit(token)
 
         core.info(`==> Repository: ${owner}/${repo}`)
-        core.info(`==> Artifact name: ${name}`)
+        core.info(`==> Artifact name(s): ${names}`)
         core.info(`==> Local path: ${path}`)
 
         if (!workflow) {
@@ -177,23 +177,17 @@ async function main() {
             run_id: runID,
         })
 
-        // One artifact if 'name' input is specified, one or more if `name` is a regular expression, all otherwise.
-        if (name) {
-            filtered = artifacts.filter((artifact) => {
-                if (nameIsRegExp) {
-                    return artifact.name.match(name) !== null
-                }
-                return artifact.name == name
-            })
-            if (filtered.length == 0) {
-                core.info(`==> (not found) Artifact: ${name}`)
-                core.info('==> Found the following artifacts instead:')
-                for (const artifact of artifacts) {
-                    core.info(`\t==> (found) Artifact: ${artifact.name}`)
-                }
-            }
-            artifacts = filtered
+        // One artifact, a list of artifacts, or all if `name` input is not specified.
+        const matchesWithRegex = (stringToTest, regexRule) => {
+            const escapeSpecialChars = (string) => string.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
+            const builtRegexRule = "^" + regexRule.split("*").map(escapeSpecialChars).join(".*") + "$"
+            return new RegExp(builtRegexRule).test(stringToTest)
         }
+
+        const artifactNames = names.split(",").map(artifactName => artifactName.trim())
+        artifacts = artifacts.filter(artifact => {
+            return artifactNames.map(name => matchesWithRegex(artifact.name, name)).reduce((prevValue, currValue) => prevValue || currValue)
+        })
 
         core.setOutput("artifacts", artifacts)
 

--- a/download-artifacts/main.js
+++ b/download-artifacts/main.js
@@ -177,7 +177,7 @@ async function main() {
             run_id: runID,
         })
 
-        // One artifact, a list of artifacts, or all if `name` input is not specified.
+        // One artifact, a list of artifacts, or all if `artifacts` input is not specified.
         const matchesWithRegex = (stringToTest, regexRule) => {
             const escapeSpecialChars = (string) => string.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
             const builtRegexRule = "^" + regexRule.split("*").map(escapeSpecialChars).join(".*") + "$"


### PR DESCRIPTION
## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🤖 Build/deploy pipeline (DevOps)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the `download-artifacts` action to fix the issue of not downloading multiple artifacts when listed in the input.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **download-artifacts/main.js:** Adds in logic to filter the list of artifacts from the workflow run based on the `artifacts` input.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
