### PR TITLE
[DEVOPS-1702] Add workflow cancellation detection to report-deployment-status-to-slack

### DIFF
--- a/report-deployment-status-to-slack/action.yml
+++ b/report-deployment-status-to-slack/action.yml
@@ -63,11 +63,16 @@ runs:
             SLACK_MESSAGE=":white_check_mark: Updated ${{ inputs.environment }} to \`${{ inputs.tag }}\` on ${{ inputs.project }}.
             ${{ inputs.url }}"
             ;;
-        
+
           failure)
             SLACK_MESSAGE=":x: Failed to update ${{ inputs.environment }} to \`${{ inputs.tag }}\` on ${{ inputs.project }}.
             ${{ inputs.url }}
             Please retry or contact @devops team."
+            ;;
+
+          cancelled)
+            SLACK_MESSAGE=":hand: Cancelled update of ${{ inputs.environment }} to \`${{ inputs.tag }}\` on ${{ inputs.project }}.
+            ${{ inputs.url }}"
             ;;
         esac
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/DEVOPS-1702

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix
-   🚀 New feature development

## 📔 Objective

When a workflow is manually cancelled, the slack message is stuck in a constant “deploying” state. As a engineer, I would like the deploy notification of an environment to update to a cancelled emoji when the workflow is cancelled

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **report-deployment-status-to-slack/action.yml:** Add `cancelled` case in switch with an appropriate message.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
