### PR TITLE
Revert "use dynamic repository"

### DIFF
--- a/.github/workflows/workflow-linter.yml
+++ b/.github/workflows/workflow-linter.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
+          repository: bitwarden/gh-actions
           fetch-depth: 0
 
       - name: Get changed files


### PR DESCRIPTION
This broke the workflow linter on pull requests.
https://github.com/bitwarden/mobile/actions/runs/7559898444/job/20584746078

Reverts bitwarden/gh-actions#238