### PR TITLE
Relax the "Run in step ... should be a single line" linter rule

### DIFF
--- a/lint-workflow/lint.py
+++ b/lint-workflow/lint.py
@@ -384,7 +384,7 @@ def lint(filename):
                             findings.append(
                                 LintFinding(
                                     f"Run in step {str(i)} of job key '{job_key}' should be a single line.",
-                                    "error",
+                                    "warning",
                                 )
                             )
 


### PR DESCRIPTION
## 🎟️ Tracking

Closes #252

## 🚧 Type of change

-   🎂 Other

## 📔 Objective

Explained in the linked issue as the first proposed suggestion.

## 📋 Code changes

Made the linter rule into a warning.

## 📸 Screenshots

N/A

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
