### PR TITLE
[DEVOPS-1919] - Set output for artifact build commit

### DIFF
--- a/download-artifacts/action.yml
+++ b/download-artifacts/action.yml
@@ -91,6 +91,8 @@ outputs:
     description: Boolean output which is true if the artifact was found and false otherwise
   artifacts:
     description: JSON array with details about found artifacts
+  artifact-build-commit:
+    description: The commit related to the artifact that was found
 runs:
   using: node20
   main: main.js

--- a/download-artifacts/main.js
+++ b/download-artifacts/main.js
@@ -191,6 +191,9 @@ async function main() {
 
         core.setOutput("artifacts", artifacts)
 
+        const artifactBuildCommit = artifacts[0].workflow_run.head_sha;
+        core.setOutput("artifact-build-commit", artifactBuildCommit)
+
         if (dryRun) {
             if (artifacts.length == 0) {
                 core.setOutput("dry_run", false)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development
-   🤖 Build/deploy pipeline (DevOps)

## 📔 Objective
With our deployments today, we simply output the commit that is in the branch used as the source of the workflow trigger. This doesn't allow us to accurately show which commit is actually deployed, especially in monorepos. This extends this artifact action to set an additional output, `artifact-build-commit:` which allows other actions to use the _real_ commit or "build commit" of the artifact. 
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **download-artifacts/main.js:** Set the new output to the value of `artifacts`.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
