### PR TITLE
BRE-342 Implement retry mechanism with error handling to get secrets from KV

### DIFF
--- a/get-keyvault-secrets/lib/KeyVaultClient.js
+++ b/get-keyvault-secrets/lib/KeyVaultClient.js
@@ -124,7 +124,7 @@ class KeyVaultClient extends AzureRestClient_1.ServiceClient {
     }
     getSecretValue(secretName, callback, attempt = 1) {
         const MAX_RETRY_ATTEMPTS = 3; // Define the maximum number of retry attempts
-        const RETRY_DELAY = 1000; // Define the delay between retries in milliseconds
+        const RETRY_DELAY = 3000; // Define the delay between retries in milliseconds
         if (!callback) {
             core.debug("Callback Cannot Be Null");
             throw new Error("Callback Cannot Be Null");

--- a/get-keyvault-secrets/lib/KeyVaultHelper.js
+++ b/get-keyvault-secrets/lib/KeyVaultHelper.js
@@ -106,7 +106,7 @@ class KeyVaultHelper {
         return new Promise((resolve, reject) => {
             this.keyVaultClient.getSecretValue(secretName, (error, secretValue) => {
                 if (error) {
-                    console.log(util.format("Could not download the secret %s. Error: %s", secretName, this.getError(error)));
+                    console.log(util.format("Error: %s", this.getError(error)));
                     core.setFailed(util.format("Could not download the secret %s", secretName));
                 }
                 else {

--- a/get-keyvault-secrets/lib/KeyVaultHelper.js
+++ b/get-keyvault-secrets/lib/KeyVaultHelper.js
@@ -106,6 +106,7 @@ class KeyVaultHelper {
         return new Promise((resolve, reject) => {
             this.keyVaultClient.getSecretValue(secretName, (error, secretValue) => {
                 if (error) {
+                    console.log(util.format("Could not download the secret %s. Error: %s", secretName, this.getError(error)));
                     core.setFailed(util.format("Could not download the secret %s", secretName));
                 }
                 else {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BRE-342](https://bitwarden.atlassian.net/browse/BRE-342)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fix `get-keyvault-secrets` action intermittent failures by implementing retry mechanism with error handling to get secrets from Azure Key Vault. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Known issues: https://github.com/bitwarden/server/actions/runs/11033476838/job/30644953330

<img width="1233" alt="image" src="https://github.com/user-attachments/assets/7716018b-6d00-4ade-b99c-97e2386f2b6f">


In [this execution](https://github.com/bitwarden/server/actions/runs/11167288532/job/31043397174) we can clearly see that the retry mechanism was executed due to the execution time, `9 seconds` compare to the `6 seconds` when the step failed (RETRY_DELAY = 3000):

<img width="1221" alt="image" src="https://github.com/user-attachments/assets/c94d54e6-d740-479c-b4ea-27e9980e7fd4">

https://github.com/bitwarden/server/actions/runs/11167289676/job/31043388477

<img width="1219" alt="Vivaldi 2024-10-03 12 33 46" src="https://github.com/user-attachments/assets/548db843-5996-4877-bc69-01fb6552cb51">


Multiple jobs were triggered:

<img width="1252" alt="image" src="https://github.com/user-attachments/assets/c7ec7608-21e3-42f3-a666-7235280d864b">


## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes


[BRE-342]: https://bitwarden.atlassian.net/browse/BRE-342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ