### PR TITLE
BRE-370 - Add rule settings for document-start and document-end markers

### DIFF
--- a/lint-workflow/.yamllint.yml
+++ b/lint-workflow/.yamllint.yml
@@ -13,6 +13,12 @@ rules:
     level: warning
   comments:
     min-spaces-from-content: 1
+  document-start: 
+    level: error
+    present: false
+  document-end:
+    level: error
+    present: false
   empty-lines:
     level: warning
   hyphens:


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
- [Card](https://bitwarden.atlassian.net/browse/BRE-370?atlOrigin=eyJpIjoiMGVlY2JlY2I4MmNiNGI4ZmFlNGMzMWU3MzNjMjRmYzMiLCJwIjoiaiJ9)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds rule settings for `document-start` and `document-end` markers for yamllint.  If a `document-start` or `document-end` marker is in the workflow file, the workflow linter will fail with an error.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
