### PR TITLE
Delete Renovate reference in dependency

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Dependencies
+**/node_modules

--- a/download-artifacts/node_modules/before-after-hook/package.json
+++ b/download-artifacts/node_modules/before-after-hook/package.json
@@ -62,10 +62,5 @@
         "prerelease": true
       }
     ]
-  },
-  "renovate": {
-    "extends": [
-      "github>gr2m/.github"
-    ]
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/gh-actions/issues/345

## 📔 Objective

There's a reference to Renovate in a dependency, so just to avoid the linked issue we can remove it. Also tells Prettier to not look at these files.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
