### PR TITLE
BRE-724: Improve the robustness of argocd CLI sync operations

### DIFF
--- a/.github/workflows/_ephemeral_environment_manager.yml
+++ b/.github/workflows/_ephemeral_environment_manager.yml
@@ -116,6 +116,22 @@ jobs:
             --password ${{ steps.retrieve-secrets.outputs.ephemeral-environment-argocd-cluster-api-secret }}
       
       - name: Sync Argo CD application
+        env:
+          ARGOCD_OPTS: --grpc-web
         run: |
           APP_NAME=$(argocd app list -o name | grep ${{ inputs.pull_request_number }})
-          argocd app sync "$APP_NAME"
+          
+          # Check if there's a running sync operation
+          APP_SYNC_STATUS=$(argocd app get "$APP_NAME" --refresh -o json | jq -r '.status.operationState.phase')
+          
+          if [ "$APP_SYNC_STATUS" == "Running" ]; then
+            echo "Found running sync operation, terminating to restart sync."
+            argocd app terminate-op "$APP_NAME"
+          fi
+          
+          # Start new sync
+          argocd app sync "$APP_NAME" \
+            --retry-limit=3 \
+            --retry-backoff-duration=5s \
+            --retry-backoff-max-duration=30s \
+            --retry-backoff-factor=2


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Improves how Argo CD CLI will handle when a sync operation is already running for ephemeral environments. This will check if an operation is already running and if so, cancel the sync operation so that a new operation (with the updated tags) will always run.

This resolves the error here: https://github.com/bitwarden/server/actions/runs/13948105343/job/39040836814?pr=5526#step:6:14
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
