### PR TITLE
Allow GitHub's merge queue bot to bypass check runs

### DIFF
--- a/.github/workflows/check-run.yml
+++ b/.github/workflows/check-run.yml
@@ -24,6 +24,7 @@ jobs:
         if: |
           steps.get-permission.outputs.require-result == 'false'
           && github.triggering_actor != 'bw-ghapp[bot]'
+          && github.triggering_actor != 'github-merge-queue[bot]'
         run: |
           echo "User ${{ github.triggering_actor }} does not have the necessary access for this repository."
           echo "Current permission level is ${{ steps.get-permission.outputs.user-permission }}."


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.slack.com/archives/C024Z7LQNLB/p1743540208424449?thread_ts=1743514779.529319&cid=C024Z7LQNLB

## 📔 Objective

Permits GitHub's merge queue bot to bypass check runs, much like our own bot. Even if merge queues are not used by us, this bot will stay and it doesn't hurt for it to be an exclusion. Anything added to a merge queue should already have met prior checks.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
