### PR TITLE
Add arguments for sonar-sources and sonar-tests

### DIFF
--- a/.github/workflows/_sonar.yml
+++ b/.github/workflows/_sonar.yml
@@ -7,6 +7,10 @@ on:
         description: "Configuration for Sonar"
         type: string
         default: "default"
+      sonar-sources:
+        type: string
+      sonar-tests:
+        type: string
       sonar-test-inclusions:
         type: string
       sonar-exclusions:
@@ -66,6 +70,8 @@ jobs:
             -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} 
             ${{ inputs.sonar-test-inclusions != '' && format('-Dsonar.test.inclusions={0}', inputs.sonar-test-inclusions) || '' }}
             ${{ inputs.sonar-exclusions != '' && format('-Dsonar.exclusions={0}', inputs.sonar-exclusions) || '' }}
+            ${{ inputs.sonar-sources != '' && format('-Dsonar.sources={0}', inputs.sonar-sources) || '' }}
+            ${{ inputs.sonar-tests != '' && format('-Dsonar.tests={0}', inputs.sonar-tests) || '' }}
 
       - name: Set up Java
         if: inputs.sonar-config == 'maven' || inputs.sonar-config == 'dotnet'
@@ -93,7 +99,9 @@ jobs:
           /d:sonar.host.url="https://sonarcloud.io" \
           ${{ contains(github.event_name, 'pull_request') && format('/d:sonar.pullrequest.key={0}', github.event.pull_request.number) || '' }} \
           ${{ inputs.sonar-test-inclusions != '' && format('/d:sonar.test.inclusions={0}', inputs.sonar-test-inclusions) || '' }} \
-          ${{ inputs.sonar-exclusions != '' && format('/d:sonar.exclusions={0}', inputs.sonar-exclusions) || '' }}
+          ${{ inputs.sonar-exclusions != '' && format('/d:sonar.exclusions={0}', inputs.sonar-exclusions) || '' }} \
+          ${{ inputs.sonar-sources != '' && format('-Dsonar.sources={0}', inputs.sonar-sources) || '' }} \
+          ${{ inputs.sonar-tests != '' && format('-Dsonar.tests={0}', inputs.sonar-tests) || '' }}
           dotnet build
           dotnet-sonarscanner end /d:sonar.token="${{ steps.get-kv-secrets.outputs.SONAR-TOKEN }}"
 
@@ -105,4 +113,6 @@ jobs:
           mvn clean install -Dgpg.skip=true sonar:sonar 
           ${{ inputs.sonar-test-inclusions != '' && format('-Dsonar.test.inclusions={0}', inputs.sonar-test-inclusions) || '' }} 
           ${{ inputs.sonar-exclusions != '' && format('-Dsonar.exclusions={0}', inputs.sonar-exclusions) || '' }} 
+          ${{ inputs.sonar-sources != '' && format('-Dsonar.sources={0}', inputs.sonar-sources) || '' }}
+          ${{ inputs.sonar-tests != '' && format('-Dsonar.tests={0}', inputs.sonar-tests) || '' }}
           ${{ contains(github.event_name, 'pull_request') && format('-Dsonar.pullrequest.key={0}', github.event.pull_request.number) || '' }}


### PR DESCRIPTION
## 🎟️ Tracking

Follow-up from bitwarden.atlassian.net/browse/VULN-254

## 📔 Objective

While reviewing the `workflow-linter` repository, I found additional parameters for Sonar that needed to be accounted for as to not lose functionality.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
