### PR TITLE
[BRE-1194] add step to disable publish github release

### DIFF
--- a/.github/workflows/_publish-mobile-github-release.yml
+++ b/.github/workflows/_publish-mobile-github-release.yml
@@ -317,7 +317,6 @@ jobs:
           echo '```json' >> $GITHUB_STEP_SUMMARY
           echo "$json" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "changed_to_state=$changed_to_state" >> $GITHUB_OUTPUT
 
       - name: Upload workflow state artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
This updated was tested during the 10/2/25 clients release

Added dry-run option to publish-store.yml

publish-store.yml will enable github release workflows once release to the ios app store is complete.

Release workflow for Password Manager removes the release from draft and marks it as latest
Release workflow for Authenticator removes the release from draft and *does not* mark it as latest, per instructions from the mobile team.

publish-github-release.yml is now publish-github-release-bwa.yml and publish-github-release-bwa.yml so that they can be enabled or disabled based on which project was released.  They now run hourly when enabled.

The workflow gh-actions/_publish-mobile-github-release.yml disables the workflow that ran it once it completes successfully. 

## 🎟️ Tracking

[Original Ticket](https://bitwarden.atlassian.net/browse/BRE-1118)
[Follow up for testing](https://bitwarden.atlassian.net/browse/BRE-1194)

## 📔 Objective

Right now the check runs at 3am M-F, so if it fails on a Friday it doesn’t run again until Monday, which causes CI jobs to fail.  This happens since they use the existing GH release to determine the version and cannot upload using the same version that’s currently rolling out.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
