### PR TITLE
Add test inputs to Sonar tests

### DIFF
--- a/.github/workflows/_sonar.yml
+++ b/.github/workflows/_sonar.yml
@@ -68,7 +68,7 @@ jobs:
           args: >
             "-Dsonar.organization=${{ github.repository_owner }}"
             "-Dsonar.projectKey=${{ github.repository_owner }}_${{ github.event.repository.name }}"
-            "-Dsonar.pullrequest.key=${{ github.event.pull_request.number }}"
+            ${{ contains(github.event_name, 'pull_request') && format('"-Dsonar.pullrequest.key={0}"', github.event.pull_request.number) || '' }}
             ${{ inputs.sonar-test-inclusions != '' && format('"-Dsonar.test.inclusions={0}"', inputs.sonar-test-inclusions) || '' }}
             ${{ inputs.sonar-exclusions != '' && format('"-Dsonar.exclusions={0}"', inputs.sonar-exclusions) || '' }}
             ${{ inputs.sonar-sources != '' && format('"-Dsonar.sources={0}"', inputs.sonar-sources) || '' }}

--- a/.github/workflows/test-sonar.yml
+++ b/.github/workflows/test-sonar.yml
@@ -10,6 +10,15 @@ on:
     branches:
       - "main"
   workflow_dispatch:
+    inputs:
+      sonar-config:
+        description: "Configuration for Sonar"
+        type: string
+        default: "default"
+      sonar-test-inclusions:
+        type: string
+      sonar-exclusions:
+        type: string
 
 permissions: {}
 
@@ -25,3 +34,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
+    with:
+      sonar-config: ${{ github.event.inputs.sonar-config }}
+      sonar-test-inclusions: ${{ github.event.inputs.sonar-test-inclusions }}
+      sonar-exclusions: ${{ github.event.inputs.sonar-exclusions }}

--- a/.github/workflows/test-sonar.yml
+++ b/.github/workflows/test-sonar.yml
@@ -16,8 +16,10 @@ on:
         type: string
         default: "default"
       sonar-test-inclusions:
+        description: "Glob pattern(s) for test files to include in Sonar analysis"
         type: string
       sonar-exclusions:
+        description: "Glob pattern(s) for files to exclude from Sonar analysis"
         type: string
 
 permissions: {}


### PR DESCRIPTION
## 🎟️ Tracking

Re-work of #424 which was super-outdated and had tons of baggage from merging.

## 📔 Objective

* Add inputs to the test-sonar fixture so that we can manually trigger it and pass the sonar scan type or any inclusions/exclusions if needed
* Make the pull-request number consistent across each type of sonar runner in the reusable workflow

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
