### PR TITLE
[BRE-1227] Make release_name mandatory

### DIFF
--- a/.github/workflows/_publish-mobile-github-release.yml
+++ b/.github/workflows/_publish-mobile-github-release.yml
@@ -6,7 +6,7 @@ on:
       release_name:
         description: 'Name prefix of the release to publish (e.g. "Password Manager")'
         type: string
-        default: ""
+        required: true
       workflow_name:
         description: 'Name of the workflow to check for previous runs (e.g. publish-github-release.yml)'
         type: string


### PR DESCRIPTION
## 🎟️ Tracking

The "Release Name" input is required to determine whether a release will be marked "latest" in Github releases.  (Authenticator does not get this tag).  This PR ensures the workflow will not run without that criteria set.

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
