### PR TITLE
Disambiguate the two scan reusable workflows

### DIFF
--- a/.github/workflows/_checkmarx.yml
+++ b/.github/workflows/_checkmarx.yml
@@ -20,7 +20,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref || github.ref }}
+  group: ${{ github.repository }}-${{ github.workflow }}-checkmarx-${{ github.event.pull_request.number || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/_sonar.yml
+++ b/.github/workflows/_sonar.yml
@@ -24,7 +24,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref || github.ref }}
+  group: ${{ github.repository }}-${{ github.workflow }}-sonar-${{ github.event.pull_request.number || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions: {}


### PR DESCRIPTION
## 🎟️ Tracking

Testing of #465 in the field.

## 📔 Objective

Workflow name clashes exist since a common `scan.yml` from the template calls the independent scan reusable workflows. Adds a clarifying name in the concurrency group.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
