### PR TITLE
Restrict cancellation of concurrent checkmarx / sonar runs in pull requests only.

### DIFF
--- a/.github/workflows/_checkmarx.yml
+++ b/.github/workflows/_checkmarx.yml
@@ -21,7 +21,7 @@ on:
 
 concurrency:
   group: ${{ github.repository }}-${{ github.workflow }}-checkmarx-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ contains(github.event_name, 'pull_request') }}
+  cancel-in-progress: true
 
 permissions: {}
 

--- a/.github/workflows/_sonar.yml
+++ b/.github/workflows/_sonar.yml
@@ -25,7 +25,7 @@ on:
 
 concurrency:
   group: ${{ github.repository }}-${{ github.workflow }}-sonar-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ contains(github.event_name, 'pull_request') }}
+  cancel-in-progress: true
 
 permissions: {}
 

--- a/.github/workflows/test-checkmarx.yml
+++ b/.github/workflows/test-checkmarx.yml
@@ -1,4 +1,5 @@
 name: Test Checkmarx
+run-name: "Checkmarx - group: ${{ github.repository }}-${{ github.workflow }}-checkmarx-${{ github.event.pull_request.number || github.run_id }}"
 
 on:
   pull_request:

--- a/.github/workflows/test-sonar.yml
+++ b/.github/workflows/test-sonar.yml
@@ -1,4 +1,5 @@
 name: Test Sonar
+run-name: "Sonar - group: ${{ github.repository }}-${{ github.workflow }}-sonar-${{ github.event.pull_request.number || github.run_id }}"
 
 on:
   pull_request:


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Restrict concurrent run grouping and cancellation to pull requests, fixing Scan workflow cancellations in protected branches, where all changes should be independently scanned, also allowing `workflow_dispatch` runs to execute independently. 

Using run ID based on the documentation example: 
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-using-a-fallback-value


## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
