### PR TITLE
Remove concurrency check in respond workflow

### DIFF
--- a/.github/workflows/_respond.yml
+++ b/.github/workflows/_respond.yml
@@ -10,10 +10,6 @@ on:
       AZURE_CLIENT_ID:
         required: true
 
-concurrency:
-  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.head_ref || github.ref }}
-  cancel-in-progress: true
-
 permissions: {}
 
 jobs:


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Concurrency checks make sense to limit duplicative work, especially when someone or something is streaming rapid changes at relevant workflows -- we want only the latest content to processed. For Claude comment responses though each action is independent and therefore doesn't need the check; this is clashing with the current concurrency group and sending cancellations for no-ops.

## 📸 Screenshots

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
