### PR TITLE
Add proxy-able composite action for CodeCov

### DIFF
--- a/codecov/action.yml
+++ b/codecov/action.yml
@@ -1,0 +1,222 @@
+name: "Codecov Proxy"
+description: "Proxy to codecov/codecov-action@v5.5.1 forcing the CLI version attribute"
+inputs:
+  base_sha:
+    description: 'The base SHA to select. This is only used in the "pr-base-picking" run command'
+    required: false
+  binary:
+    description: "The file location of a pre-downloaded version of the CLI. If specified, integrity checking will be bypassed."
+    required: false
+  codecov_yml_path:
+    description: "The location of the codecov.yml file. This is currently ONLY used for automated test selection (https://docs.codecov.com/docs/getting-started-with-ats). Note that for all other cases, the Codecov yaml will need to be located as described here: https://docs.codecov.com/docs/codecov-yaml#can-i-name-the-file-codecovyml"
+    required: false
+  commit_parent:
+    description: "SHA (with 40 chars) of what should be the parent of this commit."
+    required: false
+  directory:
+    description: "Folder to search for coverage files. Default to the current working directory"
+    required: false
+  disable_file_fixes:
+    description: "Disable file fixes to ignore common lines from coverage (e.g. blank lines or empty brackets). Read more here https://docs.codecov.com/docs/fixing-reports"
+    required: false
+    default: "false"
+  disable_search:
+    description: "Disable search for coverage files. This is helpful when specifying what files you want to upload with the files option."
+    required: false
+    default: "false"
+  disable_safe_directory:
+    description: "Disable setting safe directory. Set to true to disable."
+    required: false
+    default: "false"
+  disable_telem:
+    description: "Disable sending telemetry data to Codecov. Set to true to disable."
+    required: false
+    default: "false"
+  dry_run:
+    description: "Don't upload files to Codecov"
+    required: false
+    default: "false"
+  env_vars:
+    description: "Environment variables to tag the upload with (e.g. PYTHON | OS,PYTHON)"
+    required: false
+  exclude:
+    description: "Comma-separated list of folders to exclude from search."
+    required: false
+  fail_ci_if_error:
+    description: "On error, exit with non-zero code"
+    required: false
+    default: "false"
+  files:
+    description: "Comma-separated list of explicit files to upload. These will be added to the coverage files found for upload. If you wish to only upload the specified files, please consider using disable-search to disable uploading other files."
+    required: false
+  flags:
+    description: "Comma-separated list of flags to upload to group coverage metrics."
+    required: false
+  force:
+    description: "Only used for empty-upload run command"
+    required: false
+  git_service:
+    description: "Override the git_service (e.g. github_enterprise)"
+    required: false
+    default: "github"
+  gcov_args:
+    description: "Extra arguments to pass to gcov"
+    required: false
+  gcov_executable:
+    description: "gcov executable to run. Defaults to 'gcov'"
+    required: false
+    default: "gcov"
+  gcov_ignore:
+    description: "Paths to ignore during gcov gathering"
+    required: false
+  gcov_include:
+    description: "Paths to include during gcov gathering"
+    required: false
+  handle_no_reports_found:
+    description: "If no coverage reports are found, do not raise an exception."
+    required: false
+    default: "false"
+  job_code:
+    description: ""
+    required: false
+  name:
+    description: "Custom defined name of the upload. Visible in the Codecov UI"
+    required: false
+  network_filter:
+    description: "Specify a filter on the files listed in the network section of the Codecov report. This will only add files whose path begin with the specified filter. Useful for upload-specific path fixing."
+    required: false
+  network_prefix:
+    description: "Specify a prefix on files listed in the network section of the Codecov report. Useful to help resolve path fixing."
+    required: false
+  os:
+    description: "Override the assumed OS. Options available at cli.codecov.io"
+    required: false
+  override_branch:
+    description: "Specify the branch to be displayed with this commit on Codecov"
+    required: false
+  override_build:
+    description: "Specify the build number manually"
+    required: false
+  override_build_url:
+    description: "The URL of the build where this is running"
+    required: false
+  override_commit:
+    description: "Commit SHA (with 40 chars)"
+    required: false
+  override_pr:
+    description: "Specify the pull request number manually. Used to override pre-existing CI environment variables."
+    required: false
+  plugins:
+    description: "Comma-separated list of plugins to run. Specify `noop` to turn off all plugins"
+    required: false
+  recurse_submodules:
+    description: "Whether to enumerate files inside of submodules for path-fixing purposes. Off by default."
+    default: "false"
+  report_code:
+    description: "The code of the report if using local upload. If unsure, leave default. Read more here https://docs.codecov.com/docs/the-codecov-cli#how-to-use-local-upload"
+    required: false
+  report_type:
+    description: 'The type of file to upload, coverage by default. Possible values are "test_results", "coverage".'
+    required: false
+  root_dir:
+    description: "Root folder from which to consider paths on the network section. Defaults to current working directory."
+    required: false
+  run_command:
+    description: 'Choose which CLI command to run. Options are "upload-coverage", "empty-upload", "pr-base-picking", "send-notifications". "upload-coverage" is run by default.'
+    required: false
+    default: "upload-coverage"
+  skip_validation:
+    description: "Skip integrity checking of the CLI. This is NOT recommended."
+    required: false
+    default: "false"
+  slug:
+    description: "[Required when using the org token] Set to the owner/repo slug used instead of the private repo token. Only applicable to some Enterprise users."
+    required: false
+  swift_project:
+    description: "Specify the swift project name. Useful for optimization."
+    required: false
+  token:
+    description: "Repository Codecov token. Used to authorize report uploads"
+    required: false
+  url:
+    description: "Set to the Codecov instance URl. Used by Dedicated Enterprise Cloud customers."
+    required: false
+  use_legacy_upload_endpoint:
+    description: "Use the legacy upload endpoint."
+    required: false
+    default: "false"
+  use_oidc:
+    description: "Use OIDC instead of token. This will ignore any token supplied"
+    required: false
+    default: "false"
+  use_pypi:
+    description: "Use the pypi version of the CLI instead of from cli.codecov.io"
+    required: false
+    default: "false"
+  verbose:
+    description: "Enable verbose logging"
+    required: false
+    default: "false"
+  version:
+    description: "Which version of the Codecov CLI to use (defaults to 'latest')"
+    required: false
+    default: "latest"
+  working-directory:
+    description: "Directory in which to execute codecov.sh"
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run codecov upload
+      uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
+      with:
+        base_sha: ${{ inputs.base_sha }}
+        binary: ${{ inputs.binary }}
+        codecov_yml_path: ${{ inputs.codecov_yml_path }}
+        commit_parent: ${{ inputs.commit_parent }}
+        directory: ${{ inputs.directory }}
+        disable_file_fixes: ${{ inputs.disable_file_fixes }}
+        disable_search: ${{ inputs.disable_search }}
+        disable_safe_directory: ${{ inputs.disable_safe_directory }}
+        disable_telem: ${{ inputs.disable_telem }}
+        dry_run: ${{ inputs.dry_run }}
+        env_vars: ${{ inputs.env_vars }}
+        exclude: ${{ inputs.exclude }}
+        fail_ci_if_error: ${{ inputs.fail_ci_if_error }}
+        files: ${{ inputs.files }}
+        flags: ${{ inputs.flags }}
+        force: ${{ inputs.force }}
+        git_service: ${{ inputs.git_service }}
+        gcov_args: ${{ inputs.gcov_args }}
+        gcov_executable: ${{ inputs.gcov_executable }}
+        gcov_ignore: ${{ inputs.gcov_ignore }}
+        gcov_include: ${{ inputs.gcov_include }}
+        handle_no_reports_found: ${{ inputs.handle_no_reports_found }}
+        job_code: ${{ inputs.job_code }}
+        name: ${{ inputs.name }}
+        network_filter: ${{ inputs.network_filter }}
+        network_prefix: ${{ inputs.network_prefix }}
+        os: ${{ inputs.os }}
+        override_branch: ${{ inputs.override_branch }}
+        override_build: ${{ inputs.override_build }}
+        override_build_url: ${{ inputs.override_build_url }}
+        override_commit: ${{ inputs.override_commit }}
+        override_pr: ${{ inputs.override_pr }}
+        plugins: ${{ inputs.plugins }}
+        recurse_submodules: ${{ inputs.recurse_submodules }}
+        report_code: ${{ inputs.report_code }}
+        report_type: ${{ inputs.report_type }}
+        root_dir: ${{ inputs.root_dir }}
+        run_command: ${{ inputs.run_command }}
+        skip_validation: ${{ inputs.skip_validation }}
+        slug: ${{ inputs.slug }}
+        swift_project: ${{ inputs.swift_project }}
+        token: ${{ inputs.token }}
+        url: ${{ inputs.url }}
+        use_legacy_upload_endpoint: ${{ inputs.use_legacy_upload_endpoint }}
+        use_oidc: ${{ inputs.use_oidc }}
+        use_pypi: ${{ inputs.use_pypi }}
+        verbose: ${{ inputs.verbose }}
+        version: v11.2.3 # Do not bump until this is fixed: https://github.com/getsentry/prevent-cli/issues/101
+        working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
## 🎟️ Tracking

TBD

## 📔 Objective

In discussions with @pixman20 we talked about a way to enforce a specific version number in CodeCov across the enterprise. This, combined with a rule to forbid the *real* CodeCov action, can help. We also mentioned potentially having a custom Zizmor audit check to do the same action, but would require additional efforts at this time.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
