### PR TITLE
Move Check-Run to individual reusable workflow components

### DIFF
--- a/.github/workflows/_checkmarx.yml
+++ b/.github/workflows/_checkmarx.yml
@@ -26,9 +26,16 @@ concurrency:
 permissions: {}
 
 jobs:
+  check-run:
+    name: Check PR run
+    uses: bitwarden/gh-actions/.github/workflows/check-run.yml@main
+    permissions:
+      contents: read
+
   sast:
     name: SAST scan
     runs-on: ubuntu-24.04
+    needs: check-run
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/_sonar.yml
+++ b/.github/workflows/_sonar.yml
@@ -30,9 +30,16 @@ concurrency:
 permissions: {}
 
 jobs:
+  check-run:
+    name: Check PR run
+    uses: bitwarden/gh-actions/.github/workflows/check-run.yml@main
+    permissions:
+      contents: read
+
   quality:
     name: Quality scan
     runs-on: ubuntu-24.04
+    needs: check-run
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -9,7 +9,7 @@ on:
     types: [opened, synchronize, reopened]
     branches-ignore:
       - main
-  pull_request_target: # zizmor: ignore[dangerous-triggers]
+  pull_request_target:
     types: [opened, synchronize, reopened]
     branches:
       - "main"
@@ -17,16 +17,9 @@ on:
 permissions: {}
 
 jobs:
-  check-run:
-    name: Check PR run
-    uses: bitwarden/gh-actions/.github/workflows/check-run.yml@main
-    permissions:
-      contents: read
-
   sast:
     name: Checkmarx
     uses: bitwarden/gh-actions/.github/workflows/_checkmarx.yml@main
-    needs: check-run
     secrets:
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -40,7 +33,6 @@ jobs:
   quality:
     name: Sonar
     uses: bitwarden/gh-actions/.github/workflows/_sonar.yml@main
-    needs: check-run
     secrets:
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/test-download-artifacts.yml
+++ b/.github/workflows/test-download-artifacts.yml
@@ -3,7 +3,7 @@ name: Test Download Artifacts Action
 on:
   workflow_dispatch:
     inputs: {}
-  workflow_run: # zizmor: ignore[dangerous-triggers]
+  workflow_run:
     workflows:
       - Upload Test Artifacts
     types:


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/VULN-325

## 📔 Objective

While discussing some of the Claude workflow changes [here](https://github.com/bitwarden/gh-actions/pull/482), we opted to make our re-usable workflow files more self-contained, handling their own dependencies of `check-run.yml`. This change is reflected here, by moving it out of the `scan.yml`, and into each subsequent scanner component workflow.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
