### PR TITLE
Update respond workflow to send correct context to Claude

### DIFF
--- a/.github/workflows/_respond.yml
+++ b/.github/workflows/_respond.yml
@@ -115,5 +115,6 @@ jobs:
           anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-RESPONSE-API-KEY }}
           track_progress: true
           use_sticky_comment: true
+          prompt: ${{ github.event.comment.body || github.event.review.body || github.event.issue.body }}
           claude_args: |
             --allowedTools "mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

We are seeing that the Claude Code Action is being halted during the response flow because Claude Code isn't being handed the context properly.  The context is different because we are using reusable workflows and not workflows inside a repo.  
Sending the message context in the prompt should ensure that we trigger Claude's interactive mode through the Claude Code Action.

## 📸 Screenshots
See the below screenshot that shows the output from the Claude Code Action stopping because it lacks the right context.
<img width="763" height="343" alt="image" src="https://github.com/user-attachments/assets/986aada8-2586-45b4-8ae1-4203492f77a4" />

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
