### PR TITLE
Add step timeout to prevent runaway actions and excessive spend

### DIFF
--- a/.github/workflows/_respond.yml
+++ b/.github/workflows/_respond.yml
@@ -75,6 +75,7 @@ jobs:
     name: Claude comment
     runs-on: ubuntu-24.04
     needs: validation
+    timeout-minutes: 15
     if: needs.validation.outputs.should_comment == 'true'
     permissions:
       actions: read
@@ -110,6 +111,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
+        timeout-minutes: 10
         uses: anthropics/claude-code-action@f30f5eecfce2f34fa72e40fa5f7bcdbdcad12eb8 # v1.0.14
         with:
           anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-RESPONSE-API-KEY }}

--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -81,6 +81,7 @@ jobs:
     name: Review
     runs-on: ubuntu-24.04
     needs: validation
+    timeout-minutes: 15
     if: needs.validation.outputs.should_review == 'true'
     permissions:
       actions: read
@@ -150,6 +151,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Review with Claude Code
+        timeout-minutes: 10
         uses: anthropics/claude-code-action@8a1c4371755898f67cd97006ba7c97702d5fc4bf # v1.0.16
         with:
           anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-CODE-REVIEW-API-KEY }}


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

We have noticed that the Claude Code Action step will get _stuck_ on occasion. We need to add a reasonable timeout to the step and job to ensure that a stuck job does not impede a team's workflow nor generate excessive dollar spend. 

I researched successful workflow executions in the `bitwarden/clients` and `bitwarden/server` repos. The vast majority of successful job runs complete in under 5 minutes. We did, unfortunately, have a number of cancelled jobs that did run for nearly 1-hour 😬 I feel that having a timeout at the job and step level is appropriate to ensure a solid cost conscious solution.

## 📸 Screenshots

Ironic that the action to review this pull request got stuck at the installing Claude tooling for a number of minutes... 🤦🏼‍♂️
<img width="824" height="756" alt="image" src="https://github.com/user-attachments/assets/278171cc-6abb-4b24-9004-15bcea5ec209" />


## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
