### PR TITLE
Fix missing env vars in check-run

### DIFF
--- a/.github/workflows/check-run.yml
+++ b/.github/workflows/check-run.yml
@@ -27,7 +27,9 @@ jobs:
           steps.get-permission.outputs.require-result == 'false'
           && github.triggering_actor != 'bw-ghapp[bot]'
         env:
+          GITHUB_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
           USER_PERMISSIONS: ${{ steps.get-permission.outputs.user-permission }}
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
           echo "User ${GITHUB_TRIGGERING_ACTOR} does not have the necessary access for this repository."
           echo "Current permission level is ${USER_PERMISSIONS}."


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/VULN-285

## 📔 Objective

I was looking at a recent build and saw that the env vars for the actor and triggering_actor were not being passed properly. It looks like the potential template injection was fixed with env vars in #434, but the actual vars were never added to the workflow. Somehow this got missed.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
