### PR TITLE
Adjust validation order & skip bot triggered response workflows

### DIFF
--- a/.github/workflows/_respond.yml
+++ b/.github/workflows/_respond.yml
@@ -13,22 +13,44 @@ on:
 permissions: {}
 
 jobs:
-  check-run:
-    name: Check PR run
-    uses: ./.github/workflows/check-run.yml
-    permissions:
-      contents: read
-
   validation:
     name: Validation
-    needs: check-run
     runs-on: ubuntu-24.04
     permissions:
       contents: read
     outputs:
       should_comment: ${{ steps.validate.outputs.should_comment }}
-
     steps:
+      - name: Check triggering actor
+        id: check-actor
+        env:
+          ACTOR: ${{ github.actor }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          REVIEW_AUTHOR: ${{ github.event.review.user.login }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          # Get the actual author of the comment/review/issue
+          AUTHOR="${COMMENT_AUTHOR:-${REVIEW_AUTHOR:-${ISSUE_AUTHOR}}}"
+
+          # List of bots that should not trigger Claude responses
+          BLOCKED_BOTS=("claude[bot]" "copilot[bot]" "github-actions[bot]" "dependabot[bot]" "codecov[bot]" "sonarqubecloud[bot]" "renovate[bot]")
+
+          IS_BOT=false
+          for BOT in "${BLOCKED_BOTS[@]}"; do
+            if [ "$ACTOR" == "$BOT" ] || [ "$AUTHOR" == "$BOT" ]; then
+              IS_BOT=true
+              echo "⏭️  Blocked bot detected: $BOT - skipping workflow"
+              break
+            fi
+          done
+
+          if [ "$IS_BOT" == "true" ]; then
+            echo "is_bot=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_bot=false" >> "$GITHUB_OUTPUT"
+            echo "✅ Human user detected: $AUTHOR"
+          fi
+
       - name: Check GitHub event
         id: check-github-event
         env:
@@ -62,19 +84,31 @@ jobs:
         id: validate
         env:
           CLAUDE_MENTIONED: ${{ steps.check-github-event.outputs.claude_mentioned }}
+          IS_BOT: ${{ steps.check-actor.outputs.is_bot }}
         run: |
-          if [ "$CLAUDE_MENTIONED" == "true" ] ; then
+          if [ "$IS_BOT" == "true" ]; then
+            echo "should_comment=false" >> "$GITHUB_OUTPUT"
+            echo "⚠️  Bot-triggered - workflow will be skipped"
+          elif [ "$CLAUDE_MENTIONED" == "true" ]; then
             echo "should_comment=true" >> "$GITHUB_OUTPUT"
-            echo "✅ Validation passed - comment will proceed"
+            echo "✅ Validation passed - workflow will proceed"
           else
             echo "should_comment=false" >> "$GITHUB_OUTPUT"
-            echo "⚠️  Validation failed - comment will be skipped"
+            echo "⚠️  @claude not mentioned - workflow will be skipped"
           fi
+
+  check-run:
+    name: Check PR run
+    needs: validation
+    if: needs.validation.outputs.should_comment == 'true'
+    uses: ./.github/workflows/check-run.yml
+    permissions:
+      contents: read
 
   comment:
     name: Claude comment
     runs-on: ubuntu-24.04
-    needs: validation
+    needs: [validation, check-run]
     timeout-minutes: 15
     if: needs.validation.outputs.should_comment == 'true'
     permissions:


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

We have community users who are seeing workflow failed notifications when comments land on PRs even when it has nothing to do with Claude Code. They are seeing this because we are first executing the check permissions action.  The simplest solution today is to validate the comment and then only execute the permission check if the comment does mention `@claude`.

Also, we have noticed some additional workflow run failures because of bots that add comments. I have added a second validation to ensure bot comments do not trigger an attempt for a Claude Code response. These bots should not ever be mentioning `@claude`; however, this simple additional validation ensures we don't get into a bot battle endless loop.

## 📸 Screenshots

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
