### PR TITLE
Implement our in-house check permission

### DIFF
--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -17,15 +17,19 @@ concurrency:
 permissions: {}
 
 jobs:
-  check-run:
-    name: Check PR run
-    uses: ./.github/workflows/check-run.yml
+  check-permission:
+    name: Check permission
+    uses: ./.github/workflows/_check-permission.yml
+    with:
+      failure_mode: "skip"
+      require_permission: "write"
     permissions:
       contents: read
 
   validation:
     name: Validation
-    needs: check-run
+    needs: check-permission
+    if: needs.check-permission.outputs.should_proceed == 'true'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -80,9 +84,9 @@ jobs:
   review:
     name: Review
     runs-on: ubuntu-24.04
-    needs: validation
+    needs: [check-permission, validation]
+    if: needs.check-permission.outputs.should_proceed == 'true' && needs.validation.outputs.should_review == 'true'
     timeout-minutes: 15
-    if: needs.validation.outputs.should_review == 'true'
     permissions:
       actions: read
       contents: read
@@ -91,7 +95,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -131,7 +135,7 @@ jobs:
           echo "✅ Created temporary directory: $TEMP_DIR"
 
       - name: Check out AI plugins marketplace
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: bitwarden/ai-plugins
           path: ${{ steps.mktemp.outputs.temp_dir }}


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Follow-up PR from #494 to implement our in-house check permission in the review code workflow. 
Ensured that we also we on the latest checkout action just like we have in _respond.yml.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
