### PR TITLE
[PM-29151] Use absolute path for marketplace directory in Claude Code…

### DIFF
--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -171,7 +171,7 @@ jobs:
 
           # Create Claude Code configuration
           jq -n \
-            --arg path "$MARKETPLACE_DIR" \
+            --arg path "$(realpath "$MARKETPLACE_DIR")" \
             '{
               extraKnownMarketplaces: {
                 "bitwarden-marketplace": {


### PR DESCRIPTION
## 🎟️ Tracking

PM-29151

## 📔 Objective

This PR updates the code review workflow to use an absolute path for the marketplace directory when configuring Claude Code settings. Previously, the relative path from `mktemp -d -p .` was passed directly to the `settings.json` configuration, which could cause plugin resolution issues. 

By converting the path to absolute using `realpath`, we ensure Claude Code can reliably locate and load marketplace plugins from the temporary directory regardless of the working directory context during execution.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
