### PR TITLE
Update Claude Code Review to call our internal agent

### DIFF
--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -188,7 +188,7 @@ jobs:
             }' > ~/.claude/settings.json
 
           # Verify agent file exists
-          if [ -f "$MARKETPLACE_PATH/plugins/bitwarden-code-review/.claude-plugin/plugin.json" ]; then
+          if [ -f "$MARKETPLACE_DIR/plugins/bitwarden-code-review/.claude-plugin/plugin.json" ]; then
             echo "✅ Plugin metadata found:"
           else
             echo "⚠️  Warning: Plugin metadata not found at expected location"


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

After a lot of local digging and debugging of setting up the `extraKnownMarketplaces` settings just like we would see on the action runner, I would like to try the following changes. I also want to see the verbose output from the action for a few days to see just what Claude Code is doing when it goes down it's decision path to invoke an agent.  With the current prompt structure, I have seen Claude Code execute our agenic approach successfully. 
We can remove the verbose output in a day or two once we are confident that Claude Code CLI is routinely selecting our code review agent for the code review task.

Also, I think we can remove _most_ of our verbose file and folder validation once we feel confident about the checkout process. 

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
