### PR TITLE
Instruct Claude to Use Settings.json

### DIFF
--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -203,6 +203,7 @@ jobs:
           anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-CODE-REVIEW-API-KEY }}
           track_progress: true
           use_sticky_comment: true
+          settings: ~/.claude/settings.json
           prompt: |
             Use bitwarden-code-reviewer agent to review the currently checked out pull request changes.
           claude_args: |


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Looking through the logs it appears that the Claude Code action is actually skipping installing the extra marketplace and our plugins because it is looking for it's own input parameters. There's a setting parameter that the documentation says we can use.

## 📸 Screenshots

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
