### PR TITLE
Pass settings to Claude using raw JSON

### DIFF
--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -143,6 +143,7 @@ jobs:
           persist-credentials: false
 
       - name: Configure Claude Code with local marketplace
+        id: configure-marketplace
         env:
           MARKETPLACE_DIR: ${{ steps.mktemp.outputs.temp_dir }}
         run: |
@@ -166,11 +167,18 @@ jobs:
           fi
           echo "✅ Found plugin: bitwarden-code-review"
 
+          # Verify agent file exists
+          if [ -f "$MARKETPLACE_DIR/plugins/bitwarden-code-review/.claude-plugin/plugin.json" ]; then
+            echo "✅ Plugin metadata found in expected location."
+          else
+            echo "⚠️  Warning: Plugin metadata not found at expected location"
+          fi
+
           mkdir -p ~/.claude
           echo "✅ Created Claude Code configuration directory"
 
-          # Create Claude Code configuration
-          jq -n \
+          # Create Claude Code configuration JSON
+          SETTINGS_JSON=$(jq -n \
             --arg path "$(realpath "$MARKETPLACE_DIR")" \
             '{
               extraKnownMarketplaces: {
@@ -185,14 +193,16 @@ jobs:
                 "claude-config-validator@bitwarden-marketplace": true,
                 "bitwarden-code-review@bitwarden-marketplace": true
               }
-            }' > ~/.claude/settings.json
+            }')
 
-          # Verify agent file exists
-          if [ -f "$MARKETPLACE_DIR/plugins/bitwarden-code-review/.claude-plugin/plugin.json" ]; then
-            echo "✅ Plugin metadata found:"
-          else
-            echo "⚠️  Warning: Plugin metadata not found at expected location"
-          fi
+          # Write to file for debugging
+          echo "$SETTINGS_JSON" > ~/.claude/settings.json
+          echo "✅ Created settings file at ~/.claude/settings.json"
+
+          # Output JSON to GitHub Actions output for passing to action
+          echo "settings_json<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$SETTINGS_JSON" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
           echo "✅ Claude Code configured with local marketplace"
 
@@ -203,7 +213,7 @@ jobs:
           anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-CODE-REVIEW-API-KEY }}
           track_progress: true
           use_sticky_comment: true
-          settings: ~/.claude/settings.json
+          settings: ${{ steps.configure-marketplace.outputs.settings_json }}
           prompt: |
             Use bitwarden-code-reviewer agent to review the currently checked out pull request changes.
           claude_args: |


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Claude Code Action quickly failed because it couldn't find the settings file. 
Turning to the other option which is passing the settings to Claude using JSON instead of messing around with file pathing and why the runner cannot file the file we just created. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
