### PR TITLE
Instruct Claude Code Action to install our plugins

### DIFF
--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -214,6 +214,9 @@ jobs:
           track_progress: true
           use_sticky_comment: true
           settings: ${{ steps.configure-marketplace.outputs.settings_json }}
+          plugins: |
+            claude-config-validator@bitwarden-marketplace
+            bitwarden-code-review@bitwarden-marketplace
           prompt: |
             Use bitwarden-code-reviewer agent to review the currently checked out pull request changes.
           claude_args: |


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

We are seeing that Claude _may not_ be actually installing the plugins. We have this additional parameter that we can use to pass the names of the plugins. 
[claude-code-action / docs / usage.md](https://github.com/anthropics/claude-code-action/blob/e2eb96f51d6b7bfe4cbb1d8598c4a0238d1a62d6/docs/usage.md)

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
