### PR TITLE
Prevent Claude from repeating agent findings in code review

### DIFF
--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -287,7 +287,7 @@ jobs:
           track_progress: true
           use_sticky_comment: true
           prompt: |
-            Use bitwarden-code-reviewer agent to review the currently checked out pull request changes. The agent will provide inline comments as well as a summary comment. Place inline comments on specific lines of code that need attention, and provide the Agent's summary of overall findings at the end.
+            Use bitwarden-code-reviewer agent to review the currently checked out pull request changes. The agent will post inline comments and a summary comment directly. Do not repeat or summarize the agent's findings after it completes.
           claude_args: |
             --verbose
             --allowedTools "mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## 🎟️ Tracking

Internal change

## 📔 Objective

Updated the Claude Code prompt to explicitly instruct Claude not to repeat or summarize the bitwarden-code-reviewer agent's findings, as the agent posts all comments directly.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
