### PR TITLE
Remove review-prompt validation check.

### DIFF
--- a/.github/workflows/_respond.yml
+++ b/.github/workflows/_respond.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Run Claude Code
         id: claude
         timeout-minutes: 10
-        uses: anthropics/claude-code-action@f0c8eb29807907de7f5412d04afceb5e24817127 # v1.0.23
+        uses: anthropics/claude-code-action@0d1933529914177075d5bc3558ae3d047f188146 # v1.0.26
         with:
           anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-RESPONSE-API-KEY }}
           track_progress: true

--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -50,30 +50,12 @@ jobs:
             echo "pr_valid=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Check if prompt file exists using GitHub CLI
-        id: check-prompt
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          REF: ${{ github.event.pull_request.head.sha }}
-          FILE_PATH: ".claude/prompts/review-code.md"
-        run: |
-          if gh api "repos/$REPO/contents/$FILE_PATH?ref=$REF" --silent 2>/dev/null; then
-            echo "prompt_exists=true" >> "$GITHUB_OUTPUT"
-            echo "✅ Found $FILE_PATH in $REPO"
-          else
-            echo "prompt_exists=false" >> "$GITHUB_OUTPUT"
-            echo "⚠️  Validation: No $FILE_PATH found - skipping Claude review"
-          fi
-
       - name: Set validation result
         id: validate
         env:
           PR_VALID: ${{ steps.check-pr.outputs.pr_valid }}
-          PROMPT_EXISTS: ${{ steps.check-prompt.outputs.prompt_exists }}
         run: |
-          if [ "$PR_VALID" == "true" ] && \
-             [ "$PROMPT_EXISTS" == "true" ]; then
+          if [ "$PR_VALID" == "true" ]; then
             echo "should_review=true" >> "$GITHUB_OUTPUT"
             echo "✅ Validation passed - code review will proceed"
           else
@@ -120,7 +102,7 @@ jobs:
 
       - name: Review with Claude Code
         timeout-minutes: 10
-        uses: anthropics/claude-code-action@f0c8eb29807907de7f5412d04afceb5e24817127 # v1.0.23
+        uses: anthropics/claude-code-action@0d1933529914177075d5bc3558ae3d047f188146 # v1.0.26
         env:
           USE_AGENT_SDK: "true"
           USE_SIMPLE_PROMPT: "true"


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

We are moving away from our well-intentioned, but over-engineered code review prompting. 
We used these files as essentially gates to the workflow running. That's not needed anymore; we'll use the built in tooling from Github to stop the caller workflow from running -or- we just won't setup the workflow in said repo.  

Also bumping to the latest Claude Code Action release.
[Latest Claude Code Release](https://github.com/anthropics/claude-code-action/releases/tag/v1.0.26)
