### PR TITLE
Only review PR if label is present

### DIFF
--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       should_review: ${{ steps.validate.outputs.should_review }}
 
@@ -50,17 +51,35 @@ jobs:
             echo "pr_valid=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Check for review label
+        id: check-label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '.labels[].name')
+          if echo "$LABELS" | grep -q "^ai-review$"; then
+            echo "label_present=true" >> "$GITHUB_OUTPUT"
+            echo "✅ Validation: 'ai-review' label found"
+          else
+            echo "label_present=false" >> "$GITHUB_OUTPUT"
+            echo "⚠️ Validation: 'ai-review' label not found - skipping Claude review"
+          fi
+
       - name: Set validation result
         id: validate
         env:
           PR_VALID: ${{ steps.check-pr.outputs.pr_valid }}
+          LABEL_PRESENT: ${{ steps.check-label.outputs.label_present }}
         run: |
-          if [ "$PR_VALID" == "true" ]; then
+          if [ "$PR_VALID" == "true" ] && \
+             [ "$LABEL_PRESENT" == "true" ]; then
             echo "should_review=true" >> "$GITHUB_OUTPUT"
             echo "✅ Validation passed - code review will proceed"
           else
             echo "should_review=false" >> "$GITHUB_OUTPUT"
-            echo "⚠️  Validation failed - code review will be skipped"
+            echo "⚠️ Validation failed - code review will be skipped"
           fi
 
   review:


### PR DESCRIPTION
## 🎟️ Tracking

Discussion from https://github.com/bitwarden/gh-actions/pull/519.

## 📔 Objective

Flipping the logic of the linked PR, Claude review will only occur if there is an `ai-review` label present.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
