### PR TITLE
Trim down the prompt & align the tooling needs

### DIFF
--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -133,10 +133,7 @@ jobs:
           plugins: "bitwarden-code-review@bitwarden-marketplace"
           prompt: |
             Use bitwarden-code-reviewer agent to review the currently checked out pull request changes.
-            Use the classifying-review-findings skill to classify findings.
-            Use the posting-bitwarden-review-comments skill to format inline comments and a single summary comment.
-            Do not repeat or summarize the agent's findings after it completes.
-            Do not add excessive praise or commentary to findings.
+            Do not add commentary after the agent completes.
           claude_args: |
             --verbose
-            --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:--comment*),Bash(gh pr comment:*),Bash(./scripts/get-review-threads.sh:*),mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,Skill"
+            --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(gh pr checks:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:--comment*),Bash(gh pr comment:*),Bash(gh api graphql*reviewThreads*-f owner=*-f repo=*-F pr=*:*),Bash(./scripts/get-review-threads.sh:*),mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,Skill"


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

I worked with Claude quite a bit to align the needs of the script to retrieve resolved PR comments.  I am not great with pattern matching, but I think that this will work well. Also added a couple other read-only tools that we have seen Claude Code attempt to use while performing our agent based reviews. 

Reflection from Claude on why I am suggesting a simpler prompt:
1. The agent already knows which skills to invoke and when (Pre-Posting Checklist)
2. Telling Claude "use skill X" in the prompt doesn't make it more likely to use it - the agent instructions do that
3. The praise/commentary rules are extensively covered in AGENT.md
4. The only thing NOT in AGENT.md is the "don't add commentary after completion" - that's workflow-level behavior