### PR TITLE
Nudge Claude Code to avoid updating the Claude comment after the agent completes

### DIFF
--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -133,7 +133,9 @@ jobs:
           plugins: "bitwarden-code-review@bitwarden-marketplace"
           prompt: |
             Use bitwarden-code-reviewer agent to review the currently checked out pull request changes.
-            Do not add commentary after the agent completes.
+            The agent handles ALL GitHub interactions including the final summary comment.
+            **DO NOT** call mcp__github_comment__update_claude_comment after the agent completes.
+            After the agent completes, output only: "REVIEW COMPLETE"
           claude_args: |
             --verbose
             --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(gh pr checks:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:--comment*),Bash(gh pr comment:*),Bash(gh api graphql*reviewThreads*-f owner=*-f repo=*-F pr=*:*),Bash(./scripts/get-review-threads.sh:*),mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,Skill"


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

We are quite close to a solid, consistent PR summary comment. The last hurdle is to encourage Claude Code to not update after the agent is done. 
We'll merge this with [this ai-plugin PR](https://github.com/bitwarden/ai-plugins/pull/25)
