### PR TITLE
Avoid tracking review progress until Claude Code Action issue is resolved

### DIFF
--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -127,7 +127,7 @@ jobs:
           USE_SIMPLE_PROMPT: "true"
         with:
           anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-CODE-REVIEW-API-KEY }}
-          track_progress: true
+          # track_progress: true (uncomment once https://github.com/anthropics/claude-code-action/issues/418 is resolved)
           use_sticky_comment: true
           plugin_marketplaces: "https://github.com/bitwarden/ai-plugins.git"
           plugins: "bitwarden-code-review@bitwarden-marketplace"


### PR DESCRIPTION
## 🎟️ Tracking

Seen in some recent workflow failures.

## 📔 Objective

Claude Code's Action has a limitation on what triggers can use progress tracking, and while this is seemingly arbitrary and they have plans to remove that check, we need to avoid progress tracking for now.
