### PR TITLE
Retrieve current labels from API instead of frozen event payload

### DIFF
--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -53,7 +53,7 @@ jobs:
             exit 0
           fi
 
-LABELS=$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json labels -q '.labels[].name')
+          LABELS=$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json labels -q '.labels[].name')
           if printf '%s\n' "$LABELS" | grep -Fxq "ai-review"; then
             echo "label_present=true" >> "$GITHUB_OUTPUT"
             echo "✅ Validation: 'ai-review' label found"


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Resolve the issue where re-running the Code Review Github Action _after_ adding the `ai-review` label fails validation. 
The problem is because of the way that the `github.event.pull_request.labels.*` is frozen at trigger time (which is usually a synchronization trigger).  Instead, we need to query the PR using the `gh api` to get the most current snapshot of the labels. 

## Test Cases
Running the following locally produced the expected `ai-review` label.

```
PR_NUMBER=16954 GH_REPO="bitwarden/clients" bash -c 'LABELS=$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json labels -q ".labels[].name" || true); echo "$LABELS"'
```
