### PR TITLE
Bump Claude Code to v 1.0.29

### DIFF
--- a/.github/workflows/_respond.yml
+++ b/.github/workflows/_respond.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Run Claude Code
         id: claude
         timeout-minutes: 10
-        uses: anthropics/claude-code-action@0d1933529914177075d5bc3558ae3d047f188146 # v1.0.26
+        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         with:
           anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-RESPONSE-API-KEY }}
           track_progress: true

--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Review with Claude Code
         timeout-minutes: 10
-        uses: anthropics/claude-code-action@0d1933529914177075d5bc3558ae3d047f188146 # v1.0.26
+        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         env:
           USE_AGENT_SDK: "true"
           USE_SIMPLE_PROMPT: "true"


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Primary objective in bumping to [v1.0.29](https://github.com/anthropics/claude-code-action/releases/tag/v1.0.29) is the resolution of [CVE-2025-66414](https://github.com/advisories/GHSA-w48q-cv73-mx4w).