### PR TITLE
Simplify code review prompt

### DIFF
--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -126,4 +126,4 @@ jobs:
           claude_args: |
             --verbose
             --model opus
-            --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(gh pr checks:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:--comment*),Bash(gh pr comment:*),Bash(gh api graphql*reviewThreads*-f owner=*-f repo=*-F pr=*:*),Bash(./scripts/get-review-threads.sh:*),mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,Skill"
+            --allowedTools "Skill,Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(gh pr checks:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:--comment*),Bash(gh pr comment:*),Bash(gh api graphql*reviewThreads*-f owner=*-f repo=*-F pr=*:*),Bash(./scripts/get-review-threads.sh:*),mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Drastic simplification of our prompt to only execute our code review slash command.
Felt like the sanity check from Claude to put the Skill tool first is a worthwhile change.
We should not really be tinkering with environment variables; those were holdovers from prior work that need to be removed.

Similar very simple prompts found in [Anthropics Public Code](https://github.com/search?q=org%3Aanthropics+uses%3A+anthropics%2Fclaude-code-action+%22prompt%22&type=code).

Follow up of [ai-plugins / Code review command](https://github.com/bitwarden/ai-plugins/pull/42)

We could have more work to massage the agent and/or our skills to **always** be invoked. However, any changes for that work should be done in the actual plugin; not here. 

## 🎬 Screenshots

The following is a screenshot of the command being invoked by Claude showing syntax is correct. 

<img width="1189" height="540" alt="image" src="https://github.com/user-attachments/assets/04802a34-297c-4bf6-b884-184a9ce86b01" />

