### PR TITLE
Fix Sonar scan for Maven builds

### DIFF
--- a/.github/workflows/_sonar.yml
+++ b/.github/workflows/_sonar.yml
@@ -163,4 +163,6 @@ jobs:
             ARGS+=("-Dsonar.pullrequest.key=${_PULL_REQUEST_KEY}")
           fi
 
+          ARGS+=("-Dsonar.token=${_SONAR_TOKEN}")
+
           mvn clean install -Dgpg.skip=true sonar:sonar "${ARGS[@]}"


### PR DESCRIPTION
## 📔 Objective

While checking out a build fail at https://github.com/bitwarden/passwordless-java/actions/runs/21377589324/job/61623527293 I saw that the scan was failing due to either the projectKey, organization, or SONAR_TOKEN. The projectKey and organization values looked correct. After looking at the SONAR_TOKEN, it looks like Sonar expects it to be `SONAR_TOKEN` as an env var, and in the refactor of the Sonar reusable component, we renamed it to `_SONAR_TOKEN`. This means the token was not being passed, and the Sonar scans have been failing in this repo ever since. This PR should hopefully fix it.


## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
