### PR TITLE
🐛 fix: correct PR detection in reusable workflows

### DIFF
--- a/.github/workflows/_checkmarx.yml
+++ b/.github/workflows/_checkmarx.yml
@@ -6,7 +6,7 @@ on:
       incremental:
         description: "Perform incremental scan"
         type: boolean
-        default: ${{ contains(github.event_name, 'pull_request') }}
+        default: ${{ github.event.pull_request != null }}
       upload-sarif:
         description: "Upload SARIF output to GitHub"
         type: boolean
@@ -77,5 +77,5 @@ jobs:
         uses: github/codeql-action/upload-sarif@19b2f06db2b6f5108140aeb04014ef02b648f789 # v4.31.11
         with:
           sarif_file: cx_result.sarif
-          sha: ${{ contains(github.event_name, 'pull_request') && github.event.pull_request.head.sha || github.sha }}
-          ref: ${{ contains(github.event_name, 'pull_request') && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
+          sha: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}

--- a/.github/workflows/_sonar.yml
+++ b/.github/workflows/_sonar.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ steps.get-kv-secrets.outputs.SONAR-TOKEN }}
           SONAR_ARGS: >-
-            ${{ github.event_name == 'pull_request' && format('"-Dsonar.pullrequest.key={0}"', github.event.pull_request.number) || '' }}
+            ${{ github.event.pull_request.number && format('"-Dsonar.pullrequest.key={0}"', github.event.pull_request.number) || '' }}
             ${{ inputs.sonar-test-inclusions != '' && format('"-Dsonar.test.inclusions={0}"', inputs.sonar-test-inclusions) || '' }}
             ${{ inputs.sonar-exclusions != '' && format('"-Dsonar.exclusions={0}"', inputs.sonar-exclusions) || '' }}
             ${{ inputs.sonar-sources != '' && format('"-Dsonar.sources={0}"', inputs.sonar-sources) || '' }}
@@ -105,7 +105,7 @@ jobs:
           _SONAR_EXCLUSIONS: ${{ inputs.sonar-exclusions }}
           _SONAR_SOURCES: ${{ inputs.sonar-sources }}
           _SONAR_TESTS: ${{ inputs.sonar-tests }}
-          _PULL_REQUEST_KEY: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
+          _PULL_REQUEST_KEY: ${{ github.event.pull_request.number || '' }}
         run: |
           set -euo pipefail
           ARGS=()
@@ -142,7 +142,7 @@ jobs:
           _SONAR_EXCLUSIONS: ${{ inputs.sonar-exclusions }}
           _SONAR_SOURCES: ${{ inputs.sonar-sources }}
           _SONAR_TESTS: ${{ inputs.sonar-tests }}
-          _PULL_REQUEST_KEY: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
+          _PULL_REQUEST_KEY: ${{ github.event.pull_request.number || '' }}
         run: |
           set -euo pipefail
           ARGS=()

--- a/.github/workflows/workflow-linter.yml
+++ b/.github/workflows/workflow-linter.yml
@@ -21,13 +21,13 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: ${{ github.repository }}
-          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+          fetch-depth: ${{ github.event.pull_request && 2 || 0 }}
           persist-credentials: false
 
       - name: Check changed files for workflow changes
         id: changed-workflows
         run: |
-          if ${{ github.event_name == 'pull_request' }}; then
+          if ${{ github.event.pull_request != null }}; then
             changed_files=$(git diff --name-only --diff-filter=d -r HEAD^1 HEAD | xargs)
           else
             changed_files=$(git diff --name-only --diff-filter=d "${{ github.event.before }}" "${{ github.event.after }}" | xargs)


### PR DESCRIPTION
## 🎟️ Tracking

Found during live troubleshooting

## 📔 Objective

Fixes a bug where reusable workflows fail to detect pull request context when checking `github.event_name == 'pull_request'`.

When a workflow is invoked as a reusable workflow via `workflow_call`, the `github.event_name` context variable is set to `"workflow_call"`, not the original triggering event name. This caused PR detection logic to fail in three workflows:

- **_sonar.yml**: Pull request key was never populated, preventing Sonar from associating scan results with PRs
- **_checkmarx.yml**: Incremental scans defaulted to false and SARIF uploads used incorrect sha/ref for PRs  
- **workflow-linter.yml**: Used wrong fetch-depth and diff logic for PRs

Fixed by checking for the presence of `github.event.pull_request` instead of checking `github.event_name`.

## ⏰ Reminders before review

- [x] Contributor guidelines followed
- [x] All formatters and local linters executed and passed
- [x] Written new unit and / or integration tests where applicable
- [x] Protected functional changes with optionality (feature flags)
- [x] Used internationalization (i18n) for all UI strings
- [x] CI builds passed
- [x] Communicated to DevOps any deployment requirements
- [x] Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes