### PR TITLE
🐛 fix: use contains() for pull_request event detection in Sonar workflow

### DIFF
--- a/.github/workflows/_sonar.yml
+++ b/.github/workflows/_sonar.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ steps.get-kv-secrets.outputs.SONAR-TOKEN }}
           SONAR_ARGS: >-
-            ${{ github.event_name == 'pull_request' && format('"-Dsonar.pullrequest.key={0}"', github.event.pull_request.number) || '' }}
+            ${{ contains(github.event_name, 'pull_request') && format('"-Dsonar.pullrequest.key={0}"', github.event.pull_request.number) || '' }}
             ${{ inputs.sonar-test-inclusions != '' && format('"-Dsonar.test.inclusions={0}"', inputs.sonar-test-inclusions) || '' }}
             ${{ inputs.sonar-exclusions != '' && format('"-Dsonar.exclusions={0}"', inputs.sonar-exclusions) || '' }}
             ${{ inputs.sonar-sources != '' && format('"-Dsonar.sources={0}"', inputs.sonar-sources) || '' }}
@@ -105,7 +105,7 @@ jobs:
           _SONAR_EXCLUSIONS: ${{ inputs.sonar-exclusions }}
           _SONAR_SOURCES: ${{ inputs.sonar-sources }}
           _SONAR_TESTS: ${{ inputs.sonar-tests }}
-          _PULL_REQUEST_KEY: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
+          _PULL_REQUEST_KEY: ${{ contains(github.event_name, 'pull_request') && github.event.pull_request.number || '' }}
         run: |
           set -euo pipefail
           ARGS=()
@@ -142,7 +142,7 @@ jobs:
           _SONAR_EXCLUSIONS: ${{ inputs.sonar-exclusions }}
           _SONAR_SOURCES: ${{ inputs.sonar-sources }}
           _SONAR_TESTS: ${{ inputs.sonar-tests }}
-          _PULL_REQUEST_KEY: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
+          _PULL_REQUEST_KEY: ${{ contains(github.event_name, 'pull_request') && github.event.pull_request.number || '' }}
         run: |
           set -euo pipefail
           ARGS=()


### PR DESCRIPTION
## 🎟️ Tracking

No tracking issue - found during troubleshooting of Sonar scan execution

## 📔 Objective

Fix pull request detection in Sonar workflow to properly handle both `pull_request` and `pull_request_target` events.

The workflow was using exact equality (`github.event_name == 'pull_request'`) which failed to match `pull_request_target` events, causing the `sonar.pullrequest.key` parameter to not be set for PRs targeting the main branch. This resulted in Sonar performing full scans instead of incremental PR scans.

Changed to use `contains(github.event_name, 'pull_request')` to match both event types, making it consistent with the Checkmarx workflow which already uses this approach.

## 📸 Screenshots

N/A - workflow configuration change

## ⏰ Reminders before review

- [x] Contributor guidelines followed
- [x] All formatters and local linters executed and passed
- [ ] Written new unit and / or integration tests where applicable
- [ ] Protected functional changes with optionality (feature flags)
- [ ] Used internationalization (i18n) for all UI strings
- [ ] CI builds passed
- [ ] Communicated to DevOps any deployment requirements
- [ ] Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes