### PR TITLE
Slim down and align with our current practices

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,30 +6,16 @@
 
 <!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
 
-## 📸 Screenshots
+## 🚨 Breaking Changes
 
-<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
+<!-- Does this PR introduce any breaking changes? If so, describe the impact and migration path for users of these workflows and shared composite actions.
 
-## ⏰ Reminders before review
+For this repo, breaking changes can include renamed inputs/outputs, changed defaults, removed steps, or behavior changes that alter workflow results.
 
--   Contributor guidelines followed
--   All formatters and local linters executed and passed
--   Written new unit and / or integration tests where applicable
--   Protected functional changes with optionality (feature flags)
--   Used internationalization (i18n) for all UI strings
--   CI builds passed
--   Communicated to DevOps any deployment requirements
--   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team
+For breaking changes:
+1. Describe what changed in the workflow or action interface
+2. Explain why the change was necessary
+3. Provide migration steps and timeline (if any)
+4. Link to any paired PRs in consuming repos (if relevant)
 
-## 🦮 Reviewer guidelines
-
-<!-- Suggested interactions but feel free to use (or not) as you desire! -->
-
--   👍 (`:+1:`) or similar for great changes
--   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
--   ❓ (`:question:`) for questions
--   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
--   🎨 (`:art:`) for suggestions / improvements
--   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
--   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
--   ⛏ (`:pick:`) for minor or nitpick changes
+Otherwise, you can remove this section. -->


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Ensure that we have consistent, meaningful, and useful PR templates across our repos.  We recently moved the sections that I have removed to [Bitwarden Contributing Docs](https://contributing.bitwarden.com/contributing/pull-requests/).

I also took inspiration from the [sdk-internal](https://github.com/bitwarden/sdk-internal/blob/main/.github/PULL_REQUEST_TEMPLATE.md) repo to add in a brief section about breaking changes that I feel add value as an extra reminder when we work on these workflows.