### PR TITLE
Bump Claude Code Action & Opus 4.6

### DIFF
--- a/.github/workflows/_respond.yml
+++ b/.github/workflows/_respond.yml
@@ -116,12 +116,12 @@ jobs:
       - name: Run Claude Code
         id: claude
         timeout-minutes: 10
-        uses: anthropics/claude-code-action@f64219702d7454cf29fe32a74104be6ed43dc637 # v1.0.34
+        uses: anthropics/claude-code-action@f669191d7d1e67f08a54b0c11cf5683a9a391951 # v1.0.49
         with:
           anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-RESPONSE-API-KEY }}
           track_progress: true
           use_sticky_comment: true
           prompt: ${{ github.event.comment.body || github.event.review.body || github.event.issue.body }}
           claude_args: |
-            --model opus
+            --model claude-opus-4-6
             --allowedTools "mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Review with Claude Code
         timeout-minutes: 10
-        uses: anthropics/claude-code-action@f64219702d7454cf29fe32a74104be6ed43dc637 # v1.0.34
+        uses: anthropics/claude-code-action@f669191d7d1e67f08a54b0c11cf5683a9a391951 # v1.0.49
         with:
           anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-CODE-REVIEW-API-KEY }}
           track_progress: true
@@ -133,5 +133,5 @@ jobs:
             /bitwarden-code-review:code-review
           claude_args: |
             --verbose
-            --model opus
+            --model claude-opus-4-6
             --allowedTools "Task,Skill,Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(gh pr checks:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:--comment*),Bash(gh pr comment:*),mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Bump to version 1.0.49 of the action. Most of the changes were Claude SDK bumps with a few interesting refactoring items and bug fixes, but the biggest was Opus 4.6
[compare / v1.0.34...v1.0.49](https://github.com/anthropics/claude-code-action/compare/v1.0.34...v1.0.49). 

<img width="737" height="84" alt="image" src="https://github.com/user-attachments/assets/2722617f-d52d-4e94-8cb5-9febcbfb5bb5" />
