### PR TITLE
Revert explicit Opus model number

### DIFF
--- a/.github/workflows/_respond.yml
+++ b/.github/workflows/_respond.yml
@@ -123,5 +123,5 @@ jobs:
           use_sticky_comment: true
           prompt: ${{ github.event.comment.body || github.event.review.body || github.event.issue.body }}
           claude_args: |
-            --model claude-opus-4-6
+            --model opus
             --allowedTools "mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -133,5 +133,5 @@ jobs:
             /bitwarden-code-review:code-review
           claude_args: |
             --verbose
-            --model claude-opus-4-6
+            --model opus
             --allowedTools "Task,Skill,Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(gh pr checks:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:--comment*),Bash(gh pr comment:*),mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Given that we bumped the Claude Code Github action up past when Opus 4.6 was released, we want to double-check that we don't need the explicit version bump of the model because that's lame. We will roll this back to the prior version after testing with one of my server PRs.