### PR TITLE
[bre-1537] troubleshoot failing upload test workflow

### DIFF
--- a/.github/workflows/upload-test-artifacts.yml
+++ b/.github/workflows/upload-test-artifacts.yml
@@ -3,6 +3,14 @@ name: Upload Test Artifacts
 on:
   workflow_dispatch:
     inputs: {}
+  push:
+    branches:
+      - main
+      - "renovate/**"
+    paths:
+      - "download-artifacts/**"
+      - ".github/workflows/upload-test-artifacts.yml"
+      - ".github/workflows/test-download-artifacts.yml"
   pull_request:
     paths:
       - "download-artifacts/**"


### PR DESCRIPTION
## 🎟️ Tracking

[bre-1537](https://bitwarden.atlassian.net/browse/bre-1537)

## 📔 Objective
**The test-download-artifacts.yml workflow was failing 2 out of 9 jobs consistently**
  - "Download main" job - tries to download artifacts from the main branch
  - "Download current branch" job - tries to download artifacts from the current branch

**Root cause: The upload-test-artifacts.yml workflow only triggered on workflow_dispatch and pull_request events. It never ran on pushes to main or feature branches, so artifacts these test jobs expected to find didn't exist.**

**Proposed Fix**
Added a push trigger to upload-test-artifacts.yml that runs on:
  - Pushes to main branch
  - Pushes to renovate/** branches
  - Only when relevant files change (path filters)

This ensures artifacts are created when code is pushed to these branches, allowing the test workflow to find them.