### PR TITLE
Switch to agent mode ensuring our plugin and skills always execute

### DIFF
--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -125,16 +125,19 @@ jobs:
         uses: anthropics/claude-code-action@f669191d7d1e67f08a54b0c11cf5683a9a391951 # v1.0.49
         with:
           anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-CODE-REVIEW-API-KEY }}
-          track_progress: true
-          use_sticky_comment: true
           plugin_marketplaces: "https://github.com/bitwarden/ai-plugins.git"
           plugins: |
             bitwarden-code-review@bitwarden-marketplace
             bitwarden-software-engineer@bitwarden-marketplace
             bitwarden-security-engineer@bitwarden-marketplace
           prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+            The repository is already checked out at the PR head SHA with full git history (fetch-depth: 0).
+            You can read files directly and use git commands to inspect changes.
+
             /bitwarden-code-review:code-review
           claude_args: |
             --verbose
             --model opus
-            --allowedTools "Task,Skill,Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(gh pr checks:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:--comment*),Bash(gh pr comment:*),mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment"
+            --allowedTools "Task,Skill,Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(gh pr checks:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:--comment*),Bash(gh pr comment:*),mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

**Our custom code review skills aren't running.** If you've noticed that AI reviews feel generic — that's because they are. Our Bitwarden-specific review plugin (`bitwarden-code-review`) is being silently overridden by ~900 lines of built-in instructions we never asked for.

This PR fixes that by switching from "tag mode" to "agent mode" in the Claude Code Action.

### The Problem

`track_progress: true` forces the Claude Code Action into **tag mode** — a mode designed for `@claude`-style interactions, not automated reviews. Tag mode takes our custom prompt and buries it:

```typescript
// Agent mode (what we want):
return context.prompt;  // Our slash command, used as-is

// Tag mode (what we have today):
const defaultPrompt = generateDefaultPrompt(...); // ~900 lines of built-in instructions
return defaultPrompt + `\n\n<custom_instructions>\n${prompt}\n</custom_instructions>`;
```

Our plugin skills — the ones we invested time building — compete with (and lose to) those 900 lines of generic instructions. This is why [posting-review-summary](https://github.com/bitwarden/ai-plugins/blob/main/plugins/bitwarden-code-review/skills/posting-review-summary/SKILL.md) rarely fires.

We've invested heavily in our plugin marketplace beyond just `bitwarden-code-review`. The workflow now loads `bitwarden-software-engineer` and `bitwarden-security-engineer` — plugins with specialized skills for Bitwarden's C#/.NET patterns, Angular conventions, database architecture, and application security review. In tag mode, these plugins are loaded but effectively sidelined because Claude follows the 900-line built-in prompt instead of our skill invocations. That investment doesn't pay off until our prompt is the one driving the review.

### The Fix

Two settings removed from the `claude-code-action` step:

| Setting | Why it's removed |
|---------|-----------------|
| `track_progress: true` | This is what forces tag mode. Removing it switches to agent mode, where our prompt is the *only* instruction. No wrapping, no dilution. |
| `use_sticky_comment: true` | Sticky comment is a tag-mode-only feature — it's [created by `prepareTagMode`](https://github.com/anthropics/claude-code-action/blob/35a9e0292d36f1186f5d842b14eb575074e8b450/src/modes/tag/index.ts#L45) and has no effect in agent mode. Keeping it would be dead config. |

The `mcp__github_comment__update_claude_comment` allowed tool is also removed since that MCP tool is how tag mode updates the sticky comment — it serves no purpose in agent mode.

### What Changes for Engineers

**What gets better:**
- Our custom review skills actually execute consistently
- Review output is lower-noise and Bitwarden-specific
- The review behavior becomes deterministic, not a coin-flip

**What we need to preserve:**
- The "sticky comment" — engineers expect a single review comment that updates in-place, not a pile-up of comments on every push. This is non-negotiable for adoption. The current sticky comment is [tightly coupled to tag mode](https://github.com/anthropics/claude-code-action/blob/35a9e0292d36f1186f5d842b14eb575074e8b450/src/modes/tag/index.ts#L45) and not available in agent mode, so we'll need to build our own. The approach:
  1. **Mimic Anthropic's pattern** — embed a hidden HTML comment ID (e.g., `<!-- bitwarden-review-comment -->`) in the review comment body
  2. **New composite action** — a `find-bitwarden-review-comment` action that searches PR comments for that hidden ID and returns the comment ID if found
  3. **Update the review skill/command** — teach the `bitwarden-code-review` plugin to find and update the existing comment instead of creating a new one

  This is straightforward engineering — Anthropic already proved the pattern works. We're just owning it ourselves so it isn't coupled to a mode we don't want.

### Potential Rollout Strategy

Instead of switching everyone at once, we could introduce a second label to beta-test agent mode alongside the existing behavior:

| Label | Mode | Behavior |
|-------|------|----------|
| `ai-review` | Tag mode (current) | Sticky comment, built-in prompt wrapping — unchanged |
| `ai-review-beta` | Agent mode (new) | Our plugin as sole instruction, Bitwarden-owned sticky comment |

All new work — the composite action, skill updates, prompt changes — lives entirely behind `ai-review-beta`. The existing `ai-review` path is untouched.

**How it would work:**
1. On any PR, swap `ai-review` for `ai-review-beta`
2. Compare the review output — skill invocation, noise level, relevance
3. Swap back anytime — zero risk

**If the team wants to graduate it:**
- After a handful of reviews across a few repos, compare quality side-by-side
- If agent mode wins, make it the default on `ai-review` and deprecate the beta label

This way nobody loses anything today, and the decision to fully switch is data-driven.

### Why a Beta Label Helps the Broader Team

Right now, Mick, Patrick, and Matt are the ones iterating on the `bitwarden-code-review` plugin. That's a small blast radius for testing, but it also means changes to the review workflow carry an outsized trust burden — the rest of engineering is relying on a system they don't directly maintain.

The `ai-review-beta` label changes that dynamic:

- **Safe experimentation space** — plugin contributors can iterate on review behavior, prompt changes, and new skills without any risk to the production `ai-review` path. Break something in beta? Nobody else notices.
- **Lower barrier to contribution** — engineers outside the core three can try changes to the plugin on their own PRs by applying `ai-review-beta`. They see the results firsthand without needing to trust that someone else tested it.
- **Visible confidence building** — when the team can see beta reviews landing consistently on real PRs, the move to make it the default becomes a formality, not a leap of faith.

### What This Doesn't Break

Downstream consumers of this reusable workflow (repos like `server` and `clients`) are **not affected**. The workflow interface is unchanged — only internal behavior shifts.

<details>
<summary>Source references</summary>

- Mode detection: [src/modes/detector.ts#L14-L31](https://github.com/anthropics/claude-code-action/blob/35a9e0292d36f1186f5d842b14eb575074e8b450/src/modes/detector.ts#L14-L31)
- Prompt generation: [src/create-prompt/index.ts#L456-L484](https://github.com/anthropics/claude-code-action/blob/35a9e0292d36f1186f5d842b14eb575074e8b450/src/create-prompt/index.ts#L456)
- Sticky comment creation: [src/github/operations/comments/create-initial.ts#L32](https://github.com/anthropics/claude-code-action/blob/35a9e0292d36f1186f5d842b14eb575074e8b450/src/github/operations/comments/create-initial.ts#L32)
- Tag mode entrypoint: [src/modes/tag/index.ts#L45](https://github.com/anthropics/claude-code-action/blob/35a9e0292d36f1186f5d842b14eb575074e8b450/src/modes/tag/index.ts#L45)
- Usage docs: [docs/usage.md#L55-L66](https://github.com/anthropics/claude-code-action/blob/35a9e0292d36f1186f5d842b14eb575074e8b450/docs/usage.md?plain=1#L55-L66)

</details>
