### PR TITLE
Disabling Claude Code attribution settings & aligning our extra known marketplaces

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
+  "extraKnownMarketplaces": {
+    "bitwarden-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "bitwarden/ai-plugins"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

We do not want Claude attributions showing up in git or in pull-requests. 
We also need to ensure that our `setting.json` is in alignment with our other repos.
Following Anthropic's best practices to disable it: [Claude Code Attribution settings](https://code.claude.com/docs/en/settings#attribution-settings).