### PR TITLE
[BRE-1522] Update publish mobile GitHub release with test workflow

### DIFF
--- a/.github/workflows/_publish-mobile-github-release.yml
+++ b/.github/workflows/_publish-mobile-github-release.yml
@@ -191,10 +191,21 @@ jobs:
 
           echo "should_skip=$should_skip" >> "$GITHUB_OUTPUT"
 
+      - name: Determine Ruby version
+        id: ruby_version
+        if: steps.check_already_processed.outputs.should_skip == 'false'
+        run: |
+          if [ -f .ruby-version ]; then
+            echo "version=$(cat .ruby-version)" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=3.2" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Configure Ruby
         if: steps.check_already_processed.outputs.should_skip == 'false'
         uses: ruby/setup-ruby@90be1154f987f4dc0fe0dd0feedac9e473aa4ba8 # v1.286.0
         with:
+          ruby-version: ${{ steps.ruby_version.outputs.version }}
           bundler-cache: true
 
       - name: Install Fastlane
@@ -211,7 +222,7 @@ jobs:
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
       - name: Download Store credentials
-        if: steps.check_already_processed.outputs.should_skip == 'false'
+        if: steps.check_already_processed.outputs.should_skip == 'false' && inputs.credentials_filename != ''
         env:
           ACCOUNT_NAME: bitwardenci
           CONTAINER_NAME: mobile

--- a/.github/workflows/_publish-mobile-github-release.yml
+++ b/.github/workflows/_publish-mobile-github-release.yml
@@ -2,6 +2,13 @@ name: _publish-mobile-github-release
 
 on:
   workflow_call:
+    secrets:
+      AZURE_SUBSCRIPTION_ID:
+        required: true
+      AZURE_TENANT_ID:
+        required: true
+      AZURE_CLIENT_ID:
+        required: true
     inputs:
       release_name:
         description: 'Name prefix of the release to publish (e.g. "Password Manager")'

--- a/.github/workflows/test-publish-mobile-github-release.yml
+++ b/.github/workflows/test-publish-mobile-github-release.yml
@@ -12,8 +12,8 @@ on:
 permissions: {}
 
 jobs:
-  setup-ios-test-release:
-    name: Setup iOS Test Release
+  setup-test-release:
+    name: Setup Test Release
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -27,15 +27,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "workflow-test-ios-${{ github.run_id }}" \
+          gh release create "workflow-test-${{ github.run_id }}" \
             --draft \
             --prerelease \
             --title "Password Manager Workflow Test 1999.3.${{ github.run_number }} (0)" \
             --notes "Test draft release for workflow testing - created by test-publish-mobile-github-release.yml"
 
-  test-ios-publish-workflow:
-    name: Test iOS Publish Workflow
-    needs: setup-ios-test-release
+  test-publish-workflow:
+    name: Test Publish Workflow
+    needs: setup-test-release
     uses: ./.github/workflows/_publish-mobile-github-release.yml
     permissions:
       actions: write
@@ -51,9 +51,9 @@ jobs:
       dry_run: true
     secrets: inherit
 
-  cleanup-ios-test-release:
-    name: Cleanup iOS Test Release
-    needs: [setup-ios-test-release, test-ios-publish-workflow]
+  cleanup-test-release:
+    name: Cleanup Test Release
+    needs: [setup-test-release, test-publish-workflow]
     if: always()
     runs-on: ubuntu-24.04
     permissions:
@@ -64,80 +64,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Delete iOS workflow test release
+      - name: Delete workflow test release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          TAG="workflow-test-ios-${{ github.run_id }}"
+          TAG="workflow-test-${{ github.run_id }}"
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Deleting workflow test release [$TAG]"
             gh release delete "$TAG" --yes
           else
             echo "Release [$TAG] not found, nothing to clean up"
-          fi
-
-  setup-android-test-release:
-    name: Setup Android Test Release
-    needs: cleanup-ios-test-release
-    if: always()
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        with:
-          persist-credentials: false
-
-      - name: Create draft release for testing
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release create "workflow-test-android-${{ github.run_id }}" \
-            --draft \
-            --prerelease \
-            --title "Password Manager Workflow Test 1999.3.${{ github.run_number }} (0)" \
-            --notes "Test draft release for workflow testing - created by test-publish-mobile-github-release.yml"
-
-  test-android-publish-workflow:
-    name: Test Android Publish Workflow
-    needs: setup-android-test-release
-    uses: ./.github/workflows/_publish-mobile-github-release.yml
-    permissions:
-      actions: write
-      contents: write
-      id-token: write
-    with:
-      release_name: "Password Manager"
-      workflow_name: "test-publish-mobile-github-release.yml"
-      credentials_filename: ""
-      check_release_command: "echo 'version_name: 1999.3.${{ github.run_number }}'; echo 'version_number: 0'"
-      project_type: "android"
-      make_latest: false
-      dry_run: true
-    secrets: inherit
-
-  cleanup-android-test-release:
-    name: Cleanup Android Test Release
-    needs: [setup-android-test-release, test-android-publish-workflow]
-    if: always()
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        with:
-          persist-credentials: false
-
-      - name: Delete Android workflow test release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          TAG="workflow-test-android-${{ github.run_id }}"
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Deleting workflow test release: $TAG"
-            gh release delete "$TAG" --yes
-          else
-            echo "Release $TAG not found, nothing to clean up"
           fi

--- a/.github/workflows/test-publish-mobile-github-release.yml
+++ b/.github/workflows/test-publish-mobile-github-release.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     paths:
       - .github/workflows/_publish-mobile-github-release.yml
-  push:
-    paths:
       - .github/workflows/test-publish-mobile-github-release.yml
   workflow_dispatch:
 

--- a/.github/workflows/test-publish-mobile-github-release.yml
+++ b/.github/workflows/test-publish-mobile-github-release.yml
@@ -43,7 +43,10 @@ jobs:
       project_type: "ios"
       make_latest: false
       dry_run: true
-    secrets: inherit
+    secrets:
+        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
 
   cleanup-test-release:
     name: Cleanup Test Release

--- a/.github/workflows/test-publish-mobile-github-release.yml
+++ b/.github/workflows/test-publish-mobile-github-release.yml
@@ -18,14 +18,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Check out repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        with:
-          persist-credentials: false
-
       - name: Create draft release for testing
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           gh release create "workflow-test-${{ github.run_id }}" \
             --draft \
@@ -59,14 +55,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Check out repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        with:
-          persist-credentials: false
-
       - name: Delete workflow test release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           TAG="workflow-test-${{ github.run_id }}"
           if gh release view "$TAG" >/dev/null 2>&1; then

--- a/.github/workflows/test-publish-mobile-github-release.yml
+++ b/.github/workflows/test-publish-mobile-github-release.yml
@@ -1,0 +1,143 @@
+name: Test Publish Mobile GitHub Release
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/_publish-mobile-github-release.yml
+  push:
+    paths:
+      - .github/workflows/test-publish-mobile-github-release.yml
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  setup-ios-test-release:
+    name: Setup iOS Test Release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Create draft release for testing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "workflow-test-ios-${{ github.run_id }}" \
+            --draft \
+            --prerelease \
+            --title "Password Manager Workflow Test 1999.3.${{ github.run_number }} (0)" \
+            --notes "Test draft release for workflow testing - created by test-publish-mobile-github-release.yml"
+
+  test-ios-publish-workflow:
+    name: Test iOS Publish Workflow
+    needs: setup-ios-test-release
+    uses: ./.github/workflows/_publish-mobile-github-release.yml
+    permissions:
+      actions: write
+      contents: write
+      id-token: write
+    with:
+      release_name: "Password Manager"
+      workflow_name: "test-publish-mobile-github-release.yml"
+      credentials_filename: ""
+      check_release_command: "echo 'version_name: 1999.3.${{ github.run_number }}'; echo 'version_number: 0'"
+      project_type: "ios"
+      make_latest: false
+      dry_run: true
+    secrets: inherit
+
+  cleanup-ios-test-release:
+    name: Cleanup iOS Test Release
+    needs: [setup-ios-test-release, test-ios-publish-workflow]
+    if: always()
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Delete iOS workflow test release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="workflow-test-ios-${{ github.run_id }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Deleting workflow test release [$TAG]"
+            gh release delete "$TAG" --yes
+          else
+            echo "Release [$TAG] not found, nothing to clean up"
+          fi
+
+  setup-android-test-release:
+    name: Setup Android Test Release
+    needs: cleanup-ios-test-release
+    if: always()
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Create draft release for testing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "workflow-test-android-${{ github.run_id }}" \
+            --draft \
+            --prerelease \
+            --title "Password Manager Workflow Test 1999.3.${{ github.run_number }} (0)" \
+            --notes "Test draft release for workflow testing - created by test-publish-mobile-github-release.yml"
+
+  test-android-publish-workflow:
+    name: Test Android Publish Workflow
+    needs: setup-android-test-release
+    uses: ./.github/workflows/_publish-mobile-github-release.yml
+    permissions:
+      actions: write
+      contents: write
+      id-token: write
+    with:
+      release_name: "Password Manager"
+      workflow_name: "test-publish-mobile-github-release.yml"
+      credentials_filename: ""
+      check_release_command: "echo 'version_name: 1999.3.${{ github.run_number }}'; echo 'version_number: 0'"
+      project_type: "android"
+      make_latest: false
+      dry_run: true
+    secrets: inherit
+
+  cleanup-android-test-release:
+    name: Cleanup Android Test Release
+    needs: [setup-android-test-release, test-android-publish-workflow]
+    if: always()
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Delete Android workflow test release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="workflow-test-android-${{ github.run_id }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Deleting workflow test release: $TAG"
+            gh release delete "$TAG" --yes
+          else
+            echo "Release $TAG not found, nothing to clean up"
+          fi

--- a/publish-mobile-github-release/README.md
+++ b/publish-mobile-github-release/README.md
@@ -136,6 +136,7 @@ flowchart TB
 ### Azure Requirements
 - Azure Blob Storage account with credentials file
 - OIDC federation configured for GitHub Actions
+- Repository granted access to the necessary Blob Storage
 - Secrets configured:
   - `AZURE_SUBSCRIPTION_ID`
   - `AZURE_TENANT_ID`
@@ -223,3 +224,11 @@ The workflow creates a `release-info.json` artifact to track state across runs:
 - `changed_to_state`: State after workflow finished (`published`, `none`)
 
 This artifact is stored with a name like `release-info-password-manager` (based on the `release_name` input) and is used to prevent duplicate processing.
+
+## Regression Testing
+
+`test-publish-mobile-github-release.yml` runs automatically on PRs that change `_publish-mobile-github-release.yml`. It:
+
+1. Creates a draft release in this repo with a unique tag (`workflow-test-{run_id}`) and a title containing a fixed test version (`1999.3.{run_number} (0)`)
+2. Calls `_publish-mobile-github-release.yml` with `dry_run: true`, an empty `credentials_filename` (skips store credential download but still exercises Azure login/logout), and a fake `check_release_command` that echoes a static version number. In production, this command uses Fastlane to query the App Store or Play Store, which requires store credentials not available in this repo. The fake command just allows the workflow to continue without actually reaching out to the stores.
+3. Cleans up the draft release regardless of whether the test passed or failed

--- a/publish-mobile-github-release/README.md
+++ b/publish-mobile-github-release/README.md
@@ -117,6 +117,7 @@ flowchart TB
         I --> J
 
         L --> C
+        M --> J
 
         style Creation fill:#e1f5ff
         style Publishing fill:#e8f5e9

--- a/publish-mobile-github-release/README.md
+++ b/publish-mobile-github-release/README.md
@@ -1,0 +1,224 @@
+# Publish Mobile GitHub Release Reusable Workflow
+
+## Description
+The `_publish-mobile-github-release.yml` provides an automated way to publish GitHub draft releases when the corresponding mobile app version has been released to the App Store or Google Play Store. This workflow runs on a schedule to periodically check if draft releases should be published, ensuring that GitHub releases stay in sync with actual store releases.
+
+## Key Features
+- **Automated Publishing**: Automatically publishes draft GitHub releases when versions are live in app stores
+- **State Tracking**: Uses artifacts to track release state and prevent duplicate processing
+- **Store Version Verification**: Validates that the version is actually released on the store before publishing
+- **Self-Disabling**: Automatically disables the workflow after successful publish to prevent unnecessary runs
+- **Duplicate Prevention**: Tracks previously processed releases to avoid re-publishing manually reverted drafts
+- **Dry Run Mode**: Supports testing without making actual changes
+- **Flexible Store Integration**: Works with both iOS (App Store) and Android (Google Play) using custom verification commands
+
+## How to use it
+
+### Setup
+1. Create a caller workflow in your repository's `.github/workflows/` directory (e.g., `publish-github-release-bwpm.yml`)
+2. Configure the required inputs:
+   - `release_name`: Name prefix to search for in draft releases (e.g., "Password Manager")
+   - `workflow_name`: Name of the caller workflow file (for self-disabling functionality)
+   - `credentials_filename`: Name of credentials file in Azure Blob Storage
+   - `check_release_command`: Shell command to verify store version (must use `$CREDENTIALS_PATH` variable)
+   - `project_type`: Either "ios" or "android"
+   - `make_latest`: Whether to mark the release as the latest release
+3. Set up required Azure secrets for credential retrieval:
+   - `AZURE_SUBSCRIPTION_ID`
+   - `AZURE_TENANT_ID`
+   - `AZURE_CLIENT_ID`
+4. Configure a schedule (typically hourly on weekdays) or use `workflow_dispatch` for manual runs
+
+### Usage
+
+#### Automated (Scheduled)
+The workflow runs automatically on its configured schedule:
+1. Checks for draft releases matching the `release_name` prefix
+2. If a draft is found, downloads credentials from Azure Blob Storage
+3. Runs the `check_release_command` to verify the version is live in the store
+4. Compares the draft release version with the store version
+5. If versions match, publishes the GitHub release (makes it non-draft and non-prerelease)
+6. Disables the workflow to prevent future runs
+7. Creates an artifact tracking the release state for future reference
+
+#### Manual
+1. Navigate to **Actions** → your publish workflow in your repository
+2. Click **Run workflow**
+3. Optionally enable **dry_run** to test without making changes
+4. Click **Run workflow**
+
+### Example Configuration
+
+```yaml
+name: Publish Password Manager GitHub Release
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * 1-5' # Every hour on weekdays
+
+jobs:
+  publish-release:
+    uses: bitwarden/gh-actions/.github/workflows/_publish-mobile-github-release.yml@main
+    with:
+      release_name: "Password Manager"
+      workflow_name: "publish-github-release-bwpm.yml"
+      credentials_filename: "appstoreconnect-fastlane.json"
+      project_type: ios
+      check_release_command: >
+        bundle exec fastlane ios get_latest_version
+        api_key_path:$CREDENTIALS_PATH
+        app_identifier:com.8bit.bitwarden
+      make_latest: true
+    secrets: inherit
+```
+
+## Workflow Diagram
+```mermaid
+flowchart TB
+        subgraph Creation["Release Creation Workflow"]
+            A[Creates draft release]
+            B[Enables release publish workflow]
+        end
+
+        subgraph Publishing["Release Publish Workflow"]
+            C[Runs repeatedly via cron schedule]
+            D{Draft release<br/>exists?}
+            D2[Check previous run<br/>status artifact]
+            E{Already published<br/>this version<br/>in previous run?}
+            F{Version live<br/>on App Store?}
+            G[- Skip all other steps<br/>- Save status artifact:<br/>changed_to_state='none']
+            H[Publish GitHub release]
+            I[Save artifact:<br/>changed_to_state='published']
+            J[- Work is done<br/>- Disable self]
+        end
+
+        subgraph Scenarios["Edge Cases"]
+            K[No draft found]
+            L[Someone reverts to draft]
+            M[Abort - already processed<br/>Don't re-publish]
+        end
+
+        A --> B
+        B --> C
+        C --> D
+        D -->|Yes| D2
+        D2 --> E
+        D -->|No| K
+        K --> J
+
+        E -->|No| F
+        E -->|Yes| M
+
+        F -->|Not yet| G
+        F -->|Yes| H
+
+        G --> C
+        H --> I
+        I --> J
+
+        L --> C
+
+        style Creation fill:#e1f5ff
+        style Publishing fill:#e8f5e9
+        style Scenarios fill:#fff3e0
+        style H fill:#c8e6c9
+        style M fill:#ffcdd2
+        style G fill:#fff9c4
+```
+
+## Requirements
+
+### Repository Requirements
+- Draft GitHub releases must follow a naming pattern that includes the `release_name` (e.g., "Password Manager v2024.1.0 (123)")
+- Workflow must have `contents: write`, `id-token: write`, and `actions: write` permissions
+
+### Azure Requirements
+- Azure Blob Storage account with credentials file
+- OIDC federation configured for GitHub Actions
+- Secrets configured:
+  - `AZURE_SUBSCRIPTION_ID`
+  - `AZURE_TENANT_ID`
+  - `AZURE_CLIENT_ID`
+
+### Fastlane Requirements
+- Ruby and bundler available in the runner
+- Fastlane configured with custom lanes for version checking
+- Custom `check_release_command` must output version info in the expected format:
+  ```
+  version_name: 2024.1.0
+  version_number: 123
+  ```
+
+### Artifact Storage
+- Previous workflow runs must retain artifacts for state tracking
+- Artifact retention period should be sufficient for your release cadence
+
+## Troubleshooting
+
+### "No draft found" - Workflow disables itself
+- Verify a draft release exists in the repository
+- Check that the release name contains the configured `release_name` prefix
+- Ensure the release is still in draft state (not already published)
+- The workflow automatically disables itself when no draft is found to prevent unnecessary runs
+
+### "Already processed" error
+This occurs when the workflow detects it already published this release:
+- The release was likely published, then manually reverted to draft
+- To force reprocessing:
+  - Use manual `workflow_dispatch` trigger (bypasses this check)
+  - OR create a new release version
+- This protection prevents accidental duplicate publishing
+
+### Version mismatch - Release not published
+The draft version doesn't match the store version:
+- **For iOS**: Both `version_name` and `version_number` must match
+- **For Android**: Only `version_number` must match
+- Possible causes:
+  - App version not yet live in the store
+  - App review still in progress
+  - Different version uploaded to the store than in the draft
+  - `check_release_command` not returning expected format
+- The workflow will skip and retry on the next scheduled run
+
+### Fastlane command fails
+- Verify the credentials file exists in Azure Blob Storage with the exact filename
+- Check that the credentials file has not expired
+- Ensure the `check_release_command` is correctly formatted
+- Test the fastlane command locally with the same credentials
+- Verify the fastlane lane exists and returns the expected output format
+
+### Artifact download fails
+- Previous run may not have completed successfully
+- Artifact may have been deleted or expired
+- Workflow will continue without previous state (may re-process releases)
+- This is a non-fatal error with a warning
+
+### Workflow not disabling after publish
+- Check the `dry_run` input - workflow won't disable in dry run mode
+- Verify the workflow has `actions: write` permission
+- Check that `workflow_name` input exactly matches the filename of the caller workflow
+- Manual runs still work even if auto-disable fails
+
+### Wrong release published
+- Check that `release_name` filter is specific enough
+- The workflow publishes the **first** draft matching the name pattern
+- Consider using more specific release naming conventions
+
+## State Artifact Schema
+
+The workflow creates a `release-info.json` artifact to track state across runs:
+
+```json
+{
+  "release_tag": "2024.1.0",
+  "initial_state": "draft",
+  "changed_to_state": "published"
+}
+```
+
+**Fields:**
+- `release_tag`: Version of the release that was processed
+- `initial_state`: State when workflow started (`draft` or `published`)
+- `changed_to_state`: State after workflow finished (`published`, `none`)
+
+This artifact is stored with a name like `release-info-password-manager` (based on the `release_name` input) and is used to prevent duplicate processing.

--- a/publish-mobile-github-release/README.md
+++ b/publish-mobile-github-release/README.md
@@ -19,8 +19,8 @@ The `_publish-mobile-github-release.yml` provides an automated way to publish Gi
 2. Configure the required inputs:
    - `release_name`: Name prefix to search for in draft releases (e.g., "Password Manager")
    - `workflow_name`: Name of the caller workflow file (for self-disabling functionality)
-   - `credentials_filename`: Name of credentials file in Azure Blob Storage
-   - `check_release_command`: Shell command to verify store version (must use `$CREDENTIALS_PATH` variable)
+   - `credentials_filename`: Name of credentials file in Azure Blob Storage (pass empty string to skip credential download)
+   - `check_release_command`: Shell command to verify store version (may use `$CREDENTIALS_PATH` for the path to the credentials file)
    - `project_type`: Either "ios" or "android"
    - `make_latest`: Whether to mark the release as the latest release
 3. Set up required Azure secrets for credential retrieval:
@@ -34,7 +34,7 @@ The `_publish-mobile-github-release.yml` provides an automated way to publish Gi
 #### Automated (Scheduled)
 The workflow runs automatically on its configured schedule:
 1. Checks for draft releases matching the `release_name` prefix
-2. If a draft is found, downloads credentials from Azure Blob Storage
+2. If a draft is found and `credentials_filename` is set, downloads credentials from Azure Blob Storage
 3. Runs the `check_release_command` to verify the version is live in the store
 4. Compares the draft release version with the store version
 5. If versions match, publishes the GitHub release (makes it non-draft and non-prerelease)
@@ -130,7 +130,7 @@ flowchart TB
 ## Requirements
 
 ### Repository Requirements
-- Draft GitHub releases must follow a naming pattern that includes the `release_name` (e.g., "Password Manager v2024.1.0 (123)")
+- Draft GitHub releases must follow a naming pattern that includes the `release_name` (e.g., "Password Manager 2024.1.0 (123)")
 - Workflow must have `contents: write`, `id-token: write`, and `actions: write` permissions
 
 ### Azure Requirements


### PR DESCRIPTION
## 🎟️ Tracking
[BRE-1522](https://bitwarden.atlassian.net/browse/BRE-1522)

## 📔 Objective
Adds a regression test workflow for `_publish-mobile-github-release.yml` that runs automatically on PRs that change it, along with documentation.

### Files Added

`test-publish-mobile-github-release.yml`

Regression test workflow triggered on PRs that change `_publish-mobile-github-release.yml`. Creates a test draft release in this repo with a unique tag and test version in the title, calls the base workflow in `dry_run` mode with a fake store version check command, then cleans up the draft regardless of outcome.
The production `check_release_command` uses Fastlane to query the App Store or Play Store, which requires store credentials not available in this repo. The fake command simply echoes a version string that matches the draft release title, allowing the base workflow to continue without making any actual API calls to the stores.


`README.md`
Documents the base workflow and the regression testing approach.

### Files Modified

`_publish-mobile-github-release.yml`

Changes required to support the test:
- In production, the ruby setup reads the ruby version from the `.ruby-version` file in the iOS or Android repo. When the workflow is executed by the test workflow, there won't be a version file in this repo. Added a detection step that defaults to Ruby 3.2 if no .ruby-version file exists.
- When this workflow is executed by the test workflow, it won't have permission to download the store credential files from Azure Blob Storage. Added a conditional that skips the credential download step when the `credentials_filename` input is empty. 
- Sonar doesn't allow `secrets: inherit`. Secrets being passed into reusabale workflows need to be explicitly listed instead. When doing that in the calling workflow, the reusable workflow also needs the secrets explicitly listed.

## 🚨 Breaking Changes
The changes to `_publish-mobile-github-release.yml` listed above _shouldn't_ break the current production runs, but should be noted.

[BRE-1522]: https://bitwarden.atlassian.net/browse/BRE-1522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ