### PR TITLE
[BRE-1726] Handling edge cause for self-hosted runners.  This requires using az-login first

### DIFF
--- a/get-keyvault-secrets/dist/index.js
+++ b/get-keyvault-secrets/dist/index.js
@@ -70358,7 +70358,7 @@ async function run() {
             .split(',')
             .map((s) => s.trim())
             .filter(Boolean);
-        const credential = new defaultAzureCredential_DefaultAzureCredential();
+        const credential = new AzureCliCredential();
         const client = new SecretClient(`https://${keyvault}.vault.azure.net`, credential);
         for (const secretName of secretNames) {
             const secret = await client.getSecret(secretName);

--- a/get-keyvault-secrets/src/main.ts
+++ b/get-keyvault-secrets/src/main.ts
@@ -1,5 +1,5 @@
 import * as core from '@actions/core';
-import { DefaultAzureCredential } from '@azure/identity';
+import { AzureCliCredential } from '@azure/identity';
 import { SecretClient } from '@azure/keyvault-secrets';
 
 async function run(): Promise<void> {
@@ -11,7 +11,7 @@ async function run(): Promise<void> {
       .map((s) => s.trim())
       .filter(Boolean);
 
-    const credential = new DefaultAzureCredential();
+    const credential = new AzureCliCredential();
     const client = new SecretClient(
       `https://${keyvault}.vault.azure.net`,
       credential,


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-1726](https://bitwarden.atlassian.net/browse/BRE-1726)

## 📔 Objective

Handling edge cause for self-hosted runners.  This requires using az-login first<br/>

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

[BRE-1726]: https://bitwarden.atlassian.net/browse/BRE-1726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ