### PR TITLE
[BRE-1744] Add input to worklfow linter

### DIFF
--- a/.github/workflows/workflow-linter.yml
+++ b/.github/workflows/workflow-linter.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       repository:
-        description: "Repository to lint in org/repo format (e.g. bitwarden/server). Defaults to the current repository."
+        description: "Repository name to lint (e.g. server). Defaults to the current repository."
         required: false
         type: string
 
@@ -43,15 +43,6 @@ jobs:
         if: inputs.repository != ''
         uses: bitwarden/gh-actions/azure-logout@main
 
-      - name: Parse repository owner
-        if: inputs.repository != ''
-        id: parse-repo
-        env:
-          REPOSITORY: ${{ inputs.repository }}
-        run: |
-          echo "owner=${REPOSITORY%%/*}" >> "$GITHUB_OUTPUT"
-          echo "repo=${REPOSITORY##*/}" >> "$GITHUB_OUTPUT"
-
       - name: Generate GH App token
         if: inputs.repository != ''
         id: app-token
@@ -59,13 +50,13 @@ jobs:
         with:
           app-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
           private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
-          owner: ${{ steps.parse-repo.outputs.owner }}
-          repositories: ${{ steps.parse-repo.outputs.repo }}
+          owner: bitwarden
+          repositories: ${{ inputs.repository }}
 
       - name: Check out branch
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
-          repository: ${{ inputs.repository || github.repository }}
+          repository: ${{ inputs.repository != '' && format('bitwarden/{0}', inputs.repository) || github.repository }}
           token: ${{ steps.app-token.outputs.token || github.token }}
           fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
           persist-credentials: false


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
- [BRE-1744](https://bitwarden.atlassian.net/browse/BRE-1744?atlOrigin=eyJpIjoiYjJmZDI2MDdhNWZiNGFjNzkyYjYwOWI4NGNlMDIxYzMiLCJwIjoiaiJ9)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
As part of the work on a `bre-workflow-fix` skill for Claude during the innovation sprint, I wanted to improve the workflow linter and needed the ability to pass in a repository to test it using the `workflow_dispatch` trigger.


[BRE-1744]: https://bitwarden.atlassian.net/browse/BRE-1744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ