### PR TITLE
Promote change from tag mode to agent mode and bump action version

### DIFF
--- a/.github/workflows/_respond.yml
+++ b/.github/workflows/_respond.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Run Claude Code
         id: claude
         timeout-minutes: 10
-        uses: anthropics/claude-code-action@f669191d7d1e67f08a54b0c11cf5683a9a391951 # v1.0.49
+        uses: anthropics/claude-code-action@bee87b3258c251f9279e5371b0cc3660f37f3f77 # v1.0.83
         with:
           anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-RESPONSE-API-KEY }}
           track_progress: true

--- a/run-code-review/action.yml
+++ b/run-code-review/action.yml
@@ -72,28 +72,8 @@ runs:
         pr_number: ${{ inputs.pr_number }}
         repository: ${{ inputs.repository }}
 
-    - name: Review with Claude Code (current)
-      if: inputs.mode == 'current'
-      uses: anthropics/claude-code-action@5d0cc745cd0cce4c0e9e0b3511de26c3bc285eb5 # v1.0.71
-      with:
-        anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-CODE-REVIEW-API-KEY }}
-        track_progress: true
-        use_sticky_comment: true
-        plugin_marketplaces: "https://github.com/bitwarden/ai-plugins.git"
-        plugins: |
-          bitwarden-code-review@bitwarden-marketplace
-          bitwarden-software-engineer@bitwarden-marketplace
-          bitwarden-security-engineer@bitwarden-marketplace
-        prompt: |
-          /bitwarden-code-review:code-review
-        claude_args: |
-          --verbose
-          --model opus
-          --allowedTools "Task,Skill,Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(gh pr checks:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:--comment*),Bash(gh pr comment:*),mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment"
-
-    - name: Create PR comment placeholder (vnext)
+    - name: Create PR comment placeholder
       id: create-comment
-      if: inputs.mode == 'vnext'
       uses: bitwarden/gh-actions/update-pr-comment@main
       with:
         token: ${{ inputs.github_token }}
@@ -105,9 +85,8 @@ runs:
 
           If this comment does not update with results, check the [Actions log](${{ github.server_url }}/${{ inputs.repository }}/actions/runs/${{ github.run_id }}).
 
-    - name: Review with Claude Code (vnext)
-      if: inputs.mode == 'vnext'
-      uses: anthropics/claude-code-action@5d0cc745cd0cce4c0e9e0b3511de26c3bc285eb5 # v1.0.71
+    - name: Review with Claude Code
+      uses: anthropics/claude-code-action@bee87b3258c251f9279e5371b0cc3660f37f3f77 # v1.0.83
       with:
         anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-CODE-REVIEW-API-KEY }}
         plugin_marketplaces: "https://github.com/bitwarden/ai-plugins.git"
@@ -133,8 +112,8 @@ runs:
           --model opus
           --allowedTools "Task,Skill,Read,Write,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(gh pr checks:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:--comment*),Bash(gh pr comment:*),mcp__github_inline_comment__create_inline_comment"
 
-    - name: Update PR comment with review summary (vnext)
-      if: always() && inputs.mode == 'vnext'
+    - name: Update PR comment with review summary
+      if: always()
       uses: bitwarden/gh-actions/update-pr-comment@main
       with:
         token: ${{ inputs.github_token }}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33384](https://bitwarden.atlassian.net/browse/PM-33384)

## 📔 Objective

We have been testing the agent mode changes in the ai-review-vnext branch for quite some time now and it's time to promote it to the current way we work Claude Code Reviews. 

I made the decision to keep the validation step at the start of the action to ensure that we always verify the input mode even if we are not currently in a state of testing vNext changes.  


[PM-33384]: https://bitwarden.atlassian.net/browse/PM-33384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ