### PR TITLE
Added test mode to cherry pick workflow

### DIFF
--- a/.github/workflows/_cherry-pick.yml
+++ b/.github/workflows/_cherry-pick.yml
@@ -16,13 +16,18 @@ on:
         required: false
         type: string
         default: ''
+      test_mode:
+        description: 'Run in test mode (skips Azure auth and GPG signing)'
+        required: false
+        type: boolean
+        default: false
     secrets:
       AZURE_SUBSCRIPTION_ID:
-        required: true
+        required: false
       AZURE_TENANT_ID:
-        required: true
+        required: false
       AZURE_CLIENT_ID:
-        required: true
+        required: false
 
 permissions: {}
 
@@ -35,7 +40,8 @@ jobs:
       _DEST_BRANCH_ALLOWED: ${{ inputs.dest_branch_allowed }}
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
       id-token: write
     steps:
       - name: Validate destination branch pattern
@@ -48,6 +54,7 @@ jobs:
           echo "INFO: Destination branch matches allowed pattern"
 
       - name: Log in to Azure
+        if: ${{ !inputs.test_mode }}
         uses: bitwarden/gh-actions/azure-login@main
         with:
           subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -55,13 +62,15 @@ jobs:
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
       - name: Get Azure Key Vault secrets
+        if: ${{ !inputs.test_mode }}
         id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
           keyvault: gh-org-bitwarden
           secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
-      
+
       - name: Retrieve GPG secrets
+        if: ${{ !inputs.test_mode }}
         id: retrieve-gpg-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
@@ -69,9 +78,11 @@ jobs:
           secrets: "github-gpg-private-key, github-gpg-private-key-passphrase"
 
       - name: Log out from Azure
+        if: ${{ !inputs.test_mode }}
         uses: bitwarden/gh-actions/azure-logout@main
 
       - name: Generate GH App token
+        if: ${{ !inputs.test_mode }}
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         id: app-token
         with:
@@ -117,8 +128,7 @@ jobs:
           echo "INFO: Calling workflow: [$WORKFLOW_REF]"
 
           # if this is being run by the test-cherry-pick workflow, allow picking from the simulated main branch
-          #if [[ $WORKFLOW_REF == "bitwarden/gh-actions/.github/workflows/test-cherry-pick.yml@refs/heads/main" ]]; then ## PRODUCTION
-          if [[ $WORKFLOW_REF == "bitwarden/gh-actions/.github/workflows/test-cherry-pick.yml@refs/pull/555/merge" ]]; then  ## NEEDED FOR TESTING
+          if [[ $WORKFLOW_REF == bitwarden/gh-actions/.github/workflows/test-cherry-pick.yml@* ]]; then
               echo "INFO: This workflow is being run by the [test-cherry-pick.yml] workflow."
               if [[ ${pr_base_ref:0:21} != "cherry-pick-sim-main-" ]]; then
                 echo "ERROR: Invalid test base ref: [$pr_base_ref]. Test ref/branch must match [cherry-pick-sim-main-*]"
@@ -147,7 +157,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           ref: ${{ inputs.dest_branch }}
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ inputs.test_mode && github.token || steps.app-token.outputs.token }}
           persist-credentials: true
           fetch-depth: 0
 
@@ -157,6 +167,7 @@ jobs:
           git config --local user.email "106330231+bitwarden-devops-bot@users.noreply.github.com"
 
       - name: Setup GPG signing
+        if: ${{ !inputs.test_mode }}
         env:
           GPG_PRIVATE_KEY: ${{ steps.retrieve-gpg-secrets.outputs.github-gpg-private-key }}
           GPG_PASSPHRASE: ${{ steps.retrieve-gpg-secrets.outputs.github-gpg-private-key-passphrase }}
@@ -171,7 +182,7 @@ jobs:
       - name: Cherry pick
         env:
           PR_COMMIT: ${{ steps.validate-pr.outputs.pr_commit }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ inputs.test_mode && github.token || steps.app-token.outputs.token }}
         run: |
           echo "INFO: Cherry-picking commit [$PR_COMMIT] from PR [#$_SOURCE_PR] to branch [$_DEST_BRANCH]"
           if ! git cherry-pick -x "$PR_COMMIT"; then

--- a/.github/workflows/_cherry-pick.yml
+++ b/.github/workflows/_cherry-pick.yml
@@ -60,6 +60,13 @@ jobs:
         with:
           keyvault: gh-org-bitwarden
           secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
+      
+      - name: Retrieve GPG secrets
+        id: retrieve-gpg-secrets
+        uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        with:
+          keyvault: "bitwarden-ci"
+          secrets: "github-gpg-private-key, github-gpg-private-key-passphrase"
 
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
@@ -146,8 +153,20 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "actions@github.com"
+          git config --local user.name "bitwarden-devops-bot"
+          git config --local user.email "106330231+bitwarden-devops-bot@users.noreply.github.com"
+
+      - name: Setup GPG signing
+        env:
+          GPG_PRIVATE_KEY: ${{ steps.retrieve-gpg-secrets.outputs.github-gpg-private-key }}
+          GPG_PASSPHRASE: ${{ steps.retrieve-gpg-secrets.outputs.github-gpg-private-key-passphrase }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --import --batch
+          GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format=long | grep -o "rsa[0-9]\+/[A-F0-9]\+" | head -n1 | cut -d'/' -f2)
+          git config --local user.signingkey "$GPG_KEY_ID"
+          git config --local commit.gpgsign true
+          export GPG_TTY=$(tty)
+          echo "test" | gpg --clearsign --pinentry-mode=loopback --passphrase "$GPG_PASSPHRASE" > /dev/null 2>&1
 
       - name: Cherry pick
         env:

--- a/.github/workflows/test-cherry-pick.yml
+++ b/.github/workflows/test-cherry-pick.yml
@@ -98,13 +98,7 @@ jobs:
       source_pr: ${{ needs.setup.outputs.simulated_pr_number }}
       dest_branch: ${{ needs.setup.outputs.simulated_dest_branch }}
       dest_branch_allowed: '^cherry-pick-sim-dest-[0-9]{10}$'
-    permissions:
-      contents: read
-      id-token: write
-    secrets:
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      test_mode: true
 
   cleanup:
     # Cleanup all the simulated resources

--- a/.github/workflows/test-cherry-pick.yml
+++ b/.github/workflows/test-cherry-pick.yml
@@ -99,6 +99,10 @@ jobs:
       dest_branch: ${{ needs.setup.outputs.simulated_dest_branch }}
       dest_branch_allowed: '^cherry-pick-sim-dest-[0-9]{10}$'
       test_mode: true
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
 
   cleanup:
     # Cleanup all the simulated resources


### PR DESCRIPTION
## 📔 Objective
### Test mode
Added test mode logic to the workflow that skips the steps that require elevated permissions. The result is that when `test-cherry-pick.yml` executes `_cherry-pick.yml` when a PR is submitted, the `_cherry-pick.yml` workflow in the PR doesn't run with elevated privileges. This prevents a PR author from being able to use the privileged GH App token to perform arbitrary elevated actions.

### Added commit signing
The `cherry-pick.yml` workflow was [failing](https://github.com/bitwarden/clients/actions/runs/23652077672/job/68899325621) to push to the `rc` branch because it wasn't signing the commits. This PR adds commit signing when workflow is not running in test mode.

## 🚨 Breaking Changes
None, workflow isn't being used in production yet.
