### PR TITLE
Remove trailing backslash in Checkmarx additional_params

### DIFF
--- a/.github/workflows/_checkmarx.yml
+++ b/.github/workflows/_checkmarx.yml
@@ -67,15 +67,16 @@ jobs:
           base_uri: https://ast.checkmarx.net/
           cx_client_id: ${{ steps.get-kv-secrets.outputs.CHECKMARX-CLIENT-ID }}
           cx_client_secret: ${{ steps.get-kv-secrets.outputs.CHECKMARX-SECRET  }}
-          additional_params: |
-            --report-format sarif \
-            --filter "state=TO_VERIFY;PROPOSED_NOT_EXPLOITABLE;CONFIRMED;URGENT" \
-            --output-path . ${{ inputs.incremental && '--sast-incremental' || '' }} \
+          additional_params: >-
+            --report-format sarif
+            --filter "state=TO_VERIFY;PROPOSED_NOT_EXPLOITABLE;CONFIRMED;URGENT"
+            --output-path .
+            ${{ case(inputs.incremental, '--sast-incremental', '') }}
 
       - name: Upload Checkmarx results to GitHub
         if: inputs.upload-sarif
         uses: github/codeql-action/upload-sarif@19b2f06db2b6f5108140aeb04014ef02b648f789 # v4.31.11
         with:
           sarif_file: cx_result.sarif
-          sha: ${{ contains(github.event_name, 'pull_request') && github.event.pull_request.head.sha || github.sha }}
-          ref: ${{ contains(github.event_name, 'pull_request') && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
+          sha: ${{ case(contains(github.event_name, 'pull_request'), github.event.pull_request.head.sha, github.sha) }}
+          ref: ${{ case(contains(github.event_name, 'pull_request'), format('refs/pull/{0}/head', github.event.pull_request.number), github.ref) }}

--- a/.github/workflows/_sonar.yml
+++ b/.github/workflows/_sonar.yml
@@ -69,13 +69,13 @@ jobs:
         env:
           SONAR_TOKEN: ${{ steps.get-kv-secrets.outputs.SONAR-TOKEN }}
           SONAR_ARGS: >-
-            ${{ contains(github.event_name, 'pull_request') && format('"-Dsonar.pullrequest.key={0}"', github.event.pull_request.number) || '' }}
-            ${{ inputs.sonar-test-inclusions != '' && format('"-Dsonar.test.inclusions={0}"', inputs.sonar-test-inclusions) || '' }}
-            ${{ inputs.sonar-exclusions != '' && format('"-Dsonar.exclusions={0}"', inputs.sonar-exclusions) || '' }}
-            ${{ inputs.sonar-sources != '' && format('"-Dsonar.sources={0}"', inputs.sonar-sources) || '' }}
-            ${{ inputs.sonar-tests != '' && format('"-Dsonar.tests={0}"', inputs.sonar-tests) || '' }}
+            ${{ case(contains(github.event_name, 'pull_request'), format('"-Dsonar.pullrequest.key={0}"', github.event.pull_request.number), '') }}
+            ${{ case(inputs.sonar-test-inclusions != '', format('"-Dsonar.test.inclusions={0}"', inputs.sonar-test-inclusions), '') }}
+            ${{ case(inputs.sonar-exclusions != '', format('"-Dsonar.exclusions={0}"', inputs.sonar-exclusions), '') }}
+            ${{ case(inputs.sonar-sources != '', format('"-Dsonar.sources={0}"', inputs.sonar-sources), '') }}
+            ${{ case(inputs.sonar-tests != '', format('"-Dsonar.tests={0}"', inputs.sonar-tests), '') }}
         with:
-          args: >
+          args: >-
             "-Dsonar.organization=${{ github.repository_owner }}"
             "-Dsonar.projectKey=${{ github.repository_owner }}_${{ github.event.repository.name }}"
             ${{ env.SONAR_ARGS }}
@@ -105,7 +105,7 @@ jobs:
           _SONAR_EXCLUSIONS: ${{ inputs.sonar-exclusions }}
           _SONAR_SOURCES: ${{ inputs.sonar-sources }}
           _SONAR_TESTS: ${{ inputs.sonar-tests }}
-          _PULL_REQUEST_KEY: ${{ contains(github.event_name, 'pull_request') && github.event.pull_request.number || '' }}
+          _PULL_REQUEST_KEY: ${{ case(contains(github.event_name, 'pull_request'), github.event.pull_request.number, '') }}
         run: |
           set -euo pipefail
           ARGS=()
@@ -142,7 +142,7 @@ jobs:
           _SONAR_EXCLUSIONS: ${{ inputs.sonar-exclusions }}
           _SONAR_SOURCES: ${{ inputs.sonar-sources }}
           _SONAR_TESTS: ${{ inputs.sonar-tests }}
-          _PULL_REQUEST_KEY: ${{ contains(github.event_name, 'pull_request') && github.event.pull_request.number || '' }}
+          _PULL_REQUEST_KEY: ${{ case(contains(github.event_name, 'pull_request'), github.event.pull_request.number, '') }}
         run: |
           set -euo pipefail
           ARGS=()


### PR DESCRIPTION
## 📔 Objective

While troubleshooting some Checkmarx issues, and reading logs, I questioned if some additional output was being added to the Checkmarx docker arguments. Considering that we had an extra backslash at the end of our arguments, it's possible that the quote to close everything was being escaped improperly. I'm unsure if this will modify anything, but at least will be more correct, making everything into a single line.

While I was in these files, I changed the tiernary code lines into case() functions to make them clearer
https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case

