### PR TITLE
[PM-34709] Create workflow to categorize changes on PR for the release notes

### DIFF
--- a/.github/label-prs/README.md
+++ b/.github/label-prs/README.md
@@ -1,0 +1,145 @@
+# Label PRs
+
+Reusable workflow that automatically labels pull requests based on changed file paths and PR title patterns (conventional commit format). It uses a JSON configuration file to define labeling rules, supporting both "add" and "replace" modes for flexible label management.
+
+## Key Features
+
+- **File path matching**: Labels PRs based on which files were changed, using prefix-based patterns with `.gitignore`-style negation support.
+- **Title pattern matching**: Labels PRs based on conventional commit prefixes in the PR title (e.g., `feat:`, `fix:`, `docs:`).
+- **Two labeling modes**: "Add" mode appends labels without removing existing ones; "Replace" mode sets labels to exactly match the computed set while preserving non-managed labels.
+- **Bot and fork awareness**: Automatically uses "add" mode for bot-authored and fork PRs to avoid overwriting labels set by other automations.
+- **Dry run support**: Test labeling behavior without actually applying labels via `workflow_dispatch`.
+
+## How To Use It
+
+### Setup
+
+1. Copy the `sdlc-label-pr.yml` workflow template into your repository's `.github/workflows/` directory.
+2. Create a `.github/label-pr.json` configuration file in your repository defining `title_patterns` and `path_patterns`. See [example_label-pr.json](./example_label-pr.json) for a reference configuration.
+3. Copy the `label-pr.py` script into your repository's `.github/label-prs/` directory.
+
+### Configuration
+
+The `label-pr.json` config file has two sections:
+
+**`title_patterns`** — Maps label names to arrays of conventional commit prefixes:
+
+```json
+{
+  "title_patterns": {
+    "t:feature": ["feat", "feature"],
+    "t:bug": ["fix", "bug"],
+    "t:tech-debt": ["refactor", "chore"]
+  }
+}
+```
+
+Patterns match when the PR title contains `<pattern>:` or `<pattern>(` (case-insensitive).
+
+**`path_patterns`** — Maps label names to arrays of file path prefixes:
+
+```json
+{
+  "path_patterns": {
+    "app:shared": ["core/", "data/"],
+    "t:ci": [".github/", "scripts/"]
+  }
+}
+```
+
+Negation patterns (prefixed with `!`) exclude previously matched files, evaluated in order like `.gitignore`.
+
+### Usage
+
+The workflow triggers automatically on `pull_request` events (`opened`, `synchronize`). It can also be triggered manually via `workflow_dispatch` with the following inputs:
+
+| Input       | Type    | Default | Description                          |
+| ----------- | ------- | ------- | ------------------------------------ |
+| `pr-number` | number  | —       | Pull request number to label         |
+| `mode`      | choice  | `add`   | Labeling mode: `add` or `replace`    |
+| `dry-run`   | boolean | `false` | Run without actually applying labels |
+
+### Label Modes
+
+- **Add** (default for bot/fork PRs): Appends computed labels to the PR without removing any existing labels.
+- **Replace** (default for normal PRs): Sets the PR labels to the computed set, while preserving any labels that don't start with `app:` or `t:` prefixes.
+
+## Workflow Diagram
+
+```mermaid
+flowchart TB
+    subgraph Trigger["Triggering Event"]
+        A[pull_request: opened/synchronize<br/>OR workflow_dispatch]
+    end
+
+    subgraph Mode["Determine Label Mode"]
+        B{Is fork PR?}
+        C{Is bot PR?}
+        D[Mode: add]
+        E[Mode: replace]
+    end
+
+    subgraph Label["Label PR"]
+        F[Get changed files via gh CLI]
+        G[Get PR title via gh CLI]
+        H[Match files against path_patterns]
+        I[Match title against title_patterns]
+        J[Combine labels]
+    end
+
+    subgraph Apply["Apply Labels"]
+        K{Mode?}
+        L[Add labels to PR]
+        M[Replace PR labels<br/>preserving non-managed labels]
+    end
+
+    A --> B
+    B -->|Yes| D
+    B -->|No| C
+    C -->|Yes| D
+    C -->|No| E
+    D --> F
+    E --> F
+    F --> H
+    G --> I
+    H --> J
+    I --> J
+    J --> K
+    K -->|add| L
+    K -->|replace| M
+
+    style Trigger fill:#e1f5ff
+    style Mode fill:#fff4e1
+    style Label fill:#e8f5e9
+    style Apply fill:#f3e5f5
+```
+
+## Requirements
+
+- Python 3.9+
+- GitHub CLI (`gh`) available in the runner environment
+- A `.github/label-pr.json` configuration file in the repository
+- Labels referenced in the config must exist in the repository
+
+### GitHub Permissions
+
+| Permission      | Access | Reason                        |
+| --------------- | ------ | ----------------------------- |
+| `pull-requests` | write  | Add or replace labels on PRs  |
+| `contents`      | read   | Check out repository contents |
+
+## Troubleshooting
+
+### "Config file not found" error
+- Verify that `.github/label-pr.json` exists in your repository
+- If using a custom config path, ensure the `--config` argument is correct
+
+### No labels applied
+- Check that your `label-pr.json` patterns match the changed files or PR title
+- Title patterns require a `:` or `(` suffix (e.g., `feat:` or `feat(scope)`)
+- Path patterns use prefix matching — ensure paths in config end with `/` for directories
+- Use `workflow_dispatch` with `dry-run: true` to debug pattern matching
+
+### Labels not replaced as expected
+- Labels without `app:` or `t:` prefixes are always preserved in replace mode
+- Fork and bot PRs default to "add" mode regardless of computed mode

--- a/.github/label-prs/example_label-pr.json
+++ b/.github/label-prs/example_label-pr.json
@@ -1,0 +1,65 @@
+/**
+ * This file is used as an example configuration for the label-pr.py script.
+ * It defines patterns for labeling pull requests based on their titles and the files they modify.
+ * The patterns are organized into two main categories: title_patterns and path_patterns.
+ * Each category contains specific labels and their associated patterns to match against PR titles and modified file paths.
+ */
+
+{
+  "title_patterns": {
+    "t:feature": ["feat", "feature", "tool"],
+    "t:bug": ["fix", "bug", "bugfix"],
+    "t:tech-debt": ["refactor", "chore", "cleanup", "revert", "debt", "test", "perf"],
+    "t:docs": ["docs"],
+    "t:ci": ["ci", "build", "chore(ci)"],
+    "t:deps": ["deps"],
+    "t:breaking-change": ["breaking", "breaking-change"],
+    "t:misc": ["misc"],
+    "t:llm": ["llm"]
+  },
+  "path_patterns": {
+    "app:shared": [
+      "annotation/",
+      "core/",
+      "data/",
+      "network/",
+      "ui/",
+      "authenticatorbridge/",
+      "gradle/"
+    ],
+    "app:password-manager": [
+      "app/",
+      "cxf/",
+      "testharness/"
+    ],
+    "app:authenticator": [
+      "authenticator/"
+    ],
+    "t:feature": [
+      "app/src/main/assets/fido2_privileged_community.json",
+      "app/src/main/assets/fido2_privileged_google.json",
+      "testharness/"
+    ],
+    "t:tech-debt": [
+      "gradle.properties",
+      "keystore/"
+    ],
+    "t:ci": [
+      ".checkmarx/",
+      ".github/",
+      "scripts/",
+      "fastlane/",
+      ".gradle/",
+      "detekt-config.yml"
+    ],
+    "t:docs": [
+      "docs/"
+    ],
+    "t:deps": [
+      "gradle/"
+    ],
+    "t:llm": [
+      ".claude/"
+    ]
+  }
+}

--- a/.github/label-prs/label-pr.py
+++ b/.github/label-prs/label-pr.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+# Requires Python 3.9+
+"""
+Label pull requests based on changed file paths and PR title patterns (conventional commit format).
+
+Usage:
+    python label-pr.py <pr-number> <pr-labels> [-a|--add|-r|--replace] [-d|--dry-run] [-c|--config CONFIG]
+
+Arguments:
+    pr-number: The pull request number
+    pr-labels: Current PR labels as JSON array string
+    -a, --add: Add labels without removing existing ones (default)
+    -r, --replace: Replace all existing labels
+    -d, --dry-run: Run without actually applying labels
+    -c, --config: Path to JSON config file (default: .github/label-pr.json)
+
+Examples:
+    python label-pr.py 1234 '[]'
+    python label-pr.py 1234 '[{"name":"label1"}]' -a
+    python label-pr.py 1234 '[{"name":"label1"}]' --replace
+    python label-pr.py 1234 '[{"name":"label1"}]' -r -d
+    python label-pr.py 1234 '[]' --config custom-config.json
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+DEFAULT_MODE = "add"
+DEFAULT_CONFIG_PATH = ".github/label-pr.json"
+
+def load_config_json(config_file: str) -> dict:
+    """Load configuration from JSON file."""
+    if not os.path.exists(config_file):
+        print(f"❌ Config file not found: {config_file}")
+        sys.exit(1)
+
+    try:
+        with open(config_file, 'r') as f:
+            config = json.load(f)
+            print(f"✅ Loaded config from: {config_file}")
+
+            valid_config = True
+            if not config.get("title_patterns"):
+                print("❌ Missing 'title_patterns' in config file")
+                valid_config = False
+            if not config.get("path_patterns"):
+                print("❌ Missing 'path_patterns' in config file")
+                valid_config = False
+
+            if not valid_config:
+                print("::error::Invalid label-pr.json config file, exiting...")
+                sys.exit(1)
+
+            return config
+    except json.JSONDecodeError as e:
+        print(f"❌ JSON deserialization error in label-pr.json config: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"❌ Unexpected error loading label-pr.json config: {e}")
+        sys.exit(1)
+
+def gh_get_changed_files(pr_number: str) -> list[str]:
+    """Get list of changed files in a pull request."""
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "diff", pr_number, "--name-only"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        changed_files = result.stdout.strip().split("\n")
+        return list(filter(None, changed_files))
+    except subprocess.CalledProcessError as e:
+        print(f"::error::Error getting changed files: {e}")
+        return []
+
+def gh_get_pr_title(pr_number: str) -> str:
+    """Get the title of a pull request."""
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", pr_number, "--json", "title", "--jq", ".title"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"::error::Error getting PR title: {e}")
+        return ""
+
+def gh_add_labels(pr_number: str, labels: list[str]) -> None:
+    """Add labels to a pull request (doesn't remove existing labels)."""
+    gh_labels = ','.join(labels)
+    subprocess.run(
+        ["gh", "pr", "edit", pr_number, "--add-label", gh_labels],
+        check=True
+    )
+
+def gh_replace_labels(pr_number: str, labels: list[str]) -> None:
+    """Replace all labels on a pull request with the specified labels."""
+    payload = json.dumps({"labels": labels})
+    subprocess.run(
+        ["gh", "api", "repos/{owner}/{repo}/issues/" + pr_number, "-X", "PATCH", "--silent", "--input", "-"],
+        input=payload,
+        text=True,
+        check=True
+    )
+
+def label_filepaths(changed_files: list[str], path_patterns: dict) -> list[str]:
+    """Check changed files against path patterns and return labels to apply."""
+    if not changed_files:
+        return []
+
+    labels_to_apply = set()  # Use set to avoid duplicates
+
+    for label, patterns in path_patterns.items():
+        for file in changed_files:
+            if any(file.startswith(pattern) for pattern in patterns):
+                print(f"👀 File '{file}' matches pattern for label '{label}'")
+                labels_to_apply.add(label)
+                break
+
+    if "app:shared" in labels_to_apply:
+        labels_to_apply.add("app:password-manager")
+        labels_to_apply.add("app:authenticator")
+        labels_to_apply.remove("app:shared")
+
+    if not labels_to_apply:
+        print("::notice::No matching file paths found.")
+
+    return list(labels_to_apply)
+
+def label_title(pr_title: str, title_patterns: dict) -> list[str]:
+    """Check PR title against patterns and return labels to apply."""
+    if not pr_title:
+        return []
+
+    labels_to_apply = set()
+    title_lower = pr_title.lower()
+    for label, patterns in title_patterns.items():
+        for pattern in patterns:
+            # Check for pattern with : or ( suffix (conventional commits format)
+            if f"{pattern}:" in title_lower or f"{pattern}(" in title_lower:
+                print(f"📝 Title matches pattern '{pattern}' for label '{label}'")
+                labels_to_apply.add(label)
+                break
+
+    if not labels_to_apply:
+        print("::notice::No matching title patterns found.")
+
+    return list(labels_to_apply)
+
+def parse_pr_labels(pr_labels_str: str) -> list[str]:
+    """Parse PR labels from JSON array string."""
+    try:
+        labels = json.loads(pr_labels_str)
+        if not isinstance(labels, list):
+            print("::warning::Failed to parse PR labels: not a list")
+            return []
+        return [item.get("name") for item in labels if item.get("name")]
+    except (json.JSONDecodeError, TypeError) as e:
+        print(f"::error::Error parsing PR labels: {e}")
+        return []
+
+def get_preserved_labels(pr_labels_str: str) -> list[str]:
+    """Get existing PR labels that should be preserved (exclude app: and t: labels)."""
+    existing_labels = parse_pr_labels(pr_labels_str)
+    print(f"🔍 Parsed PR labels: {existing_labels}")
+    preserved_labels = [label for label in existing_labels if not (label.startswith("app:") or label.startswith("t:"))]
+    if preserved_labels:
+        print(f"🔍 Preserving existing labels: {', '.join(preserved_labels)}")
+    return preserved_labels
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Label pull requests based on changed file paths and PR title patterns."
+    )
+    parser.add_argument(
+        "pr_number",
+        help="The pull request number"
+    )
+
+    parser.add_argument(
+        "pr_labels",
+        help="Current PR labels (JSON array)"
+    )
+
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
+        "-a", "--add",
+        action="store_true",
+        help="Add labels without removing existing ones (default)"
+    )
+    mode_group.add_argument(
+        "-r", "--replace",
+        action="store_true",
+        help="Replace all existing labels"
+    )
+
+    parser.add_argument(
+        "-d", "--dry-run",
+        action="store_true",
+        help="Run without actually applying labels"
+    )
+
+    parser.add_argument(
+        "-c", "--config",
+        default=DEFAULT_CONFIG_PATH,
+        help=f"Path to JSON config file (default: {DEFAULT_CONFIG_PATH})"
+    )
+    args, unknown = parser.parse_known_args() # required to handle --dry-run passed as an empty string ("") by the workflow
+    return args
+
+def main():
+    args = parse_args()
+    config = load_config_json(args.config)
+    LABEL_TITLE_PATTERNS = config["title_patterns"]
+    LABEL_PATH_PATTERNS = config["path_patterns"]
+
+    pr_number = args.pr_number
+    mode = "replace" if args.replace else "add"
+
+    if args.dry_run:
+        print("🔍 DRY RUN MODE - Labels will not be applied")
+    print(f"📌 Labeling mode: {mode}")
+    print(f"🔍 Checking PR #{pr_number}...")
+
+    pr_title = gh_get_pr_title(pr_number)
+    print(f"📋 PR Title: {pr_title}\n")
+
+    changed_files = gh_get_changed_files(pr_number)
+    print("👀 Changed files:\n" + "\n".join(changed_files) + "\n")
+
+    filepath_labels = label_filepaths(changed_files, LABEL_PATH_PATTERNS)
+    title_labels = label_title(pr_title, LABEL_TITLE_PATTERNS)
+    all_labels = set(filepath_labels + title_labels)
+
+    if all_labels:
+        print("--------------------------------")
+        labels_str = ', '.join(sorted(all_labels))
+        if mode == "add":
+            print(f"::notice::🏷️ Adding labels: {labels_str}")
+            if not args.dry_run:
+                gh_add_labels(pr_number, list(all_labels))
+        else:
+            preserved_labels = get_preserved_labels(args.pr_labels)
+            if preserved_labels:
+                all_labels.update(preserved_labels)
+                labels_str = ', '.join(sorted(all_labels))
+            print(f"::notice::🏷️ Replacing labels with: {labels_str}")
+            if not args.dry_run:
+                gh_replace_labels(pr_number, list(all_labels))
+    else:
+        print("::warning::No matching patterns found, no labels applied.")
+
+    print("✅ Done")
+
+if __name__ == "__main__":
+    main()

--- a/.github/label-prs/label-pr.py
+++ b/.github/label-prs/label-pr.py
@@ -109,6 +109,25 @@ def gh_replace_labels(pr_number: str, labels: list[str]) -> None:
         check=True
     )
 
+def file_matches_patterns(file: str, patterns: list[str]) -> bool:
+    """Check if a file matches the pattern list using .gitignore-style negation.
+
+    Patterns are evaluated in order:
+    - Regular patterns (e.g. "libs/") include files starting with that prefix.
+    - Negation patterns (e.g. "!libs/angular/") exclude previously matched files.
+
+    The last matching pattern wins, just like .gitignore.
+    """
+    matched = False
+    for pattern in patterns:
+        if pattern.startswith("!"):
+            if file.startswith(pattern[1:]):
+                matched = False
+        else:
+            if file.startswith(pattern):
+                matched = True
+    return matched
+
 def label_filepaths(changed_files: list[str], path_patterns: dict) -> list[str]:
     """Check changed files against path patterns and return labels to apply."""
     if not changed_files:
@@ -118,7 +137,7 @@ def label_filepaths(changed_files: list[str], path_patterns: dict) -> list[str]:
 
     for label, patterns in path_patterns.items():
         for file in changed_files:
-            if any(file.startswith(pattern) for pattern in patterns):
+            if file_matches_patterns(file, patterns):
                 print(f"👀 File '{file}' matches pattern for label '{label}'")
                 labels_to_apply.add(label)
                 break

--- a/.github/label-prs/sdlc-label-pr.yml
+++ b/.github/label-prs/sdlc-label-pr.yml
@@ -1,0 +1,90 @@
+name: SDLC / Label PR
+run-name: Label PR ${{ github.event.pull_request.number || inputs.pr-number }}${{ github.event_name == 'workflow_dispatch' && format(' / mode "{0}" dry-run "{1}"', inputs.mode, inputs.dry-run) || '' }}
+on:
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: "Pull Request Number"
+        required: true
+        type: number
+      mode:
+        description: "Labeling Mode"
+        type: choice
+        options:
+          - add
+          - replace
+        default: add
+      dry-run:
+        description: "Dry Run - Don't apply labels"
+        type: boolean
+        default: false
+
+env:
+  _PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr-number }}
+
+jobs:
+  label-pr:
+    name: Label PR by Changed Files
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write # required to update labels
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
+
+      - name: Determine label mode for Pull Request
+        id: label-mode
+        env:
+          GH_TOKEN: ${{ github.token }}
+          _PR_USER: ${{ github.event.pull_request.user.login }}
+          _IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          # Support workflow_dispatch testing by retrieving PR data
+          if [ -z "$_PR_USER" ]; then
+            echo "👀 PR User is empty, retrieving PR data for PR #$_PR_NUMBER..."
+            PR_DATA=$(gh pr view "$_PR_NUMBER" --json author,isCrossRepository)
+            _PR_USER=$(echo "$PR_DATA" | jq -r '.author.login')
+            _IS_FORK=$(echo "$PR_DATA" | jq -r '.isCrossRepository')
+          fi
+
+          echo "📋 PR User: $_PR_USER"
+          echo "📋 Is Fork: $_IS_FORK"
+
+          # Handle PRs with labels set by other automations by adding instead of replacing
+          if [ "$_IS_FORK" = "true" ]; then
+            echo "➡️ Fork PR ($_PR_USER). Label mode: --add"
+            echo "label_mode=--add" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$_PR_USER" == app/* || "$_PR_USER" == *\[bot\] ]]; then
+            echo "➡️ Bot PR ($_PR_USER). Label mode: --add"
+            echo "label_mode=--add" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "➡️ Normal PR. Label mode: --replace"
+          echo "label_mode=--replace" >> "$GITHUB_OUTPUT"
+
+      - name: Label PR based on changed files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          _LABEL_MODE: ${{ inputs.mode && format('--{0}', inputs.mode) || steps.label-mode.outputs.label_mode }}
+          _DRY_RUN: ${{ inputs.dry-run == true && '--dry-run' || '' }}
+          _PR_LABELS: ${{ toJSON(github.event.pull_request.labels) }}
+        run: |
+          if [ -z "$_PR_LABELS" ] || [ "$_PR_LABELS" = "null" ] || [ "$_PR_LABELS" = "[]" ]; then
+            echo "🔍 No current PR labels found, retrieving PR data for PR #$_PR_NUMBER..."
+            _PR_LABELS=$(gh pr view "$_PR_NUMBER" --json labels --jq '.labels')
+          fi
+          echo "🔍 Labeling PR #$_PR_NUMBER with mode: \"$_LABEL_MODE\" and dry-run: \"$_DRY_RUN\" and current PR labels: \"$_PR_LABELS\"..."
+          echo "🐍 Running label-pr.py script..."
+          echo ""
+          python3 .github/scripts/label-pr.py "$_PR_NUMBER" "$_PR_LABELS" "$_LABEL_MODE" "$_DRY_RUN"
+

--- a/.github/label-prs/sdlc-label-pr.yml
+++ b/.github/label-prs/sdlc-label-pr.yml
@@ -86,5 +86,5 @@ jobs:
           echo "🔍 Labeling PR #$_PR_NUMBER with mode: \"$_LABEL_MODE\" and dry-run: \"$_DRY_RUN\" and current PR labels: \"$_PR_LABELS\"..."
           echo "🐍 Running label-pr.py script..."
           echo ""
-          python3 .github/scripts/label-pr.py "$_PR_NUMBER" "$_PR_LABELS" "$_LABEL_MODE" "$_DRY_RUN"
+          python3 label-pr.py "$_PR_NUMBER" "$_PR_LABELS" "$_LABEL_MODE" "$_DRY_RUN"
 


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-34709

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Originally built by @vvolkgang to categorize PRs by change type and applying labels accordingly (t:feature, t:bugfix, t:deps, etc).
It uses PR title (conventional commits) and changed files to identify and categorize.

This is already in use on the [bitwarden/android](https://github.com/bitwarden/android/blob/main/.github/workflows/sdlc-label-pr.yml) and [bitwarden/ios](https://github.com/bitwarden/ios/blob/main/.github/workflows/sdlc-label-pr.yml), but now that it will also be needed on the bitwarden/clients and bitwarden/server repos.

Goal is to centralize the workflow/scripts and to simplify the existing workflows and easily use them in the other two.
