### PR TITLE
Fix to set latest on PWM release notes only

### DIFF
--- a/.github/workflows/_publish-mobile-github-release.yml
+++ b/.github/workflows/_publish-mobile-github-release.yml
@@ -284,11 +284,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           LATEST: ${{ inputs.make_latest }}
         run: |
-          if [ "$LATEST" ]; then
-            gh release edit "$TAG" --prerelease=false --latest --draft=false
-          else
-            gh release edit "$TAG" --prerelease=false --draft=false
-          fi
+          gh release edit "$TAG" --prerelease=false --latest="$LATEST" --draft=false
 
       - name: Disable workflow if published
         if: ${{ steps.make_release_latest.conclusion == 'success' }}


### PR DESCRIPTION
## 📔 Objective

Not explicitly declaring `--latest=false` when setting `--draft=false` was allowing BWA to be marked as Latest when that honor should only be given to PWM. This fixes that.
