### PR TITLE
[BRE-1809] Add SDLC PR label check workflow

### DIFF
--- a/.github/workflows/_enforce-pr-labels-sdlc.yml
+++ b/.github/workflows/_enforce-pr-labels-sdlc.yml
@@ -1,0 +1,65 @@
+name: SDLC / Enforce PR labels
+run-name: Enforce labels for PR ${{ github.event.pull_request.number }}
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, reopened, edited, synchronize]
+
+permissions: {}
+
+jobs:
+  enforce-label:
+    name: Enforce Label
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Enforce banned labels (e.g. hold, needs-qa)
+        env:
+          _HOLD_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'hold') }}
+          _NEEDS_QA_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'needs-qa') }}
+        run: |
+          if [ "$_HOLD_LABEL" = "true" ]; then
+            echo "::error::PR has banned label: hold"
+            exit 1
+          fi
+          if [ "$_NEEDS_QA_LABEL" = "true" ]; then
+            echo "::error::PR has banned label: needs-qa"
+            exit 1
+          fi
+          echo "✅ No banned labels found."
+
+      - name: Enforce exactly one Change Type (t:*) label
+        env:
+          _PR_ACTION: ${{ github.event.action }}
+          _PR_LABELS: ${{ toJSON(github.event.pull_request.labels) }}
+          _REPO: ${{ github.repository }}
+          _PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "$_PR_ACTION" = "opened" ] || [ "$_PR_ACTION" = "reopened" ]; then
+            echo "⏳ Waiting 15s for labeler to run..."
+            sleep 15
+            _PR_LABELS=$(gh api "repos/$_REPO/pulls/$_PR_NUMBER" --jq '.labels')
+            echo "Labels fetched from PR: $_PR_LABELS"
+          fi
+          _IGNORE_FOR_RELEASE_LABEL=$(echo "$_PR_LABELS" | jq 'any(.[]; .name == "ignore-for-release")')
+          if [ "$_IGNORE_FOR_RELEASE_LABEL" = "true" ]; then
+            echo "⏭️ Skipping type label check - 'ignore-for-release' label present"
+            exit 0
+          fi
+          _T_LABEL_COUNT=$(echo "$_PR_LABELS" | jq '[.[] | select(.name | startswith("t:"))] | length')
+          case "$_T_LABEL_COUNT" in
+            1)
+              echo "✅ PR has exactly one Change Type (t:*) label"
+              ;;
+            0)
+              echo "::error::PR is missing a Change Type (t:*) label. PRs must have exactly one Change Type (t:*) label"
+              exit 1
+              ;;
+            *)
+              echo "::error::PR has $_T_LABEL_COUNT Change Type (t:*) labels. PRs must have exactly one Change Type (t:*) label"
+              exit 1
+              ;;
+          esac
+

--- a/.github/workflows/_enforce-pr-labels-sdlc.yml
+++ b/.github/workflows/_enforce-pr-labels-sdlc.yml
@@ -61,11 +61,11 @@ jobs:
               echo "✅ PR has exactly one Change Type (t:*) label" | tee -a $GITHUB_STEP_SUMMARY
               ;;
             0)
-              echo ":error: PR is missing a Change Type (t:*) label. PRs must have exactly one Change Type (t:*) label" | tee -a $GITHUB_STEP_SUMMARY
+              echo ":x: PR is missing a Change Type (t:*) label. PRs must have exactly one Change Type (t:*) label" | tee -a $GITHUB_STEP_SUMMARY
               exit 1
               ;;
             *)
-              echo ":error: PR has $_T_LABEL_COUNT Change Type (t:*) labels. PRs must have exactly one Change Type (t:*) label" | tee -a $GITHUB_STEP_SUMMARY
+              echo ":x: PR has $_T_LABEL_COUNT Change Type (t:*) labels. PRs must have exactly one Change Type (t:*) label" | tee -a $GITHUB_STEP_SUMMARY
               exit 1
               ;;
           esac

--- a/.github/workflows/_enforce-pr-labels-sdlc.yml
+++ b/.github/workflows/_enforce-pr-labels-sdlc.yml
@@ -4,6 +4,13 @@ run-name: Enforce labels for PR ${{ github.event.pull_request.number }}
 on:
   pull_request:
     types: [labeled, unlabeled, opened, reopened, edited, synchronize]
+  workflow_call:
+    inputs:
+      test_pr_labels_json:
+        description: 'JSON label array for testing (e.g. [{"name":"t:bug"}]). Skips event context when provided.'
+        required: false
+        type: string
+        default: ''
 
 permissions: {}
 
@@ -16,23 +23,23 @@ jobs:
     steps:
       - name: Enforce banned labels (e.g. hold, needs-qa)
         env:
-          _HOLD_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'hold') }}
-          _NEEDS_QA_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'needs-qa') }}
+          _HOLD_LABEL: ${{ inputs.test_pr_labels_json != '' && contains(fromJSON(inputs.test_pr_labels_json).*.name, 'hold') || contains(github.event.pull_request.labels.*.name, 'hold') }}
+          _NEEDS_QA_LABEL: ${{ inputs.test_pr_labels_json != '' && contains(fromJSON(inputs.test_pr_labels_json).*.name, 'needs-qa') || contains(github.event.pull_request.labels.*.name, 'needs-qa') }}
         run: |
           if [ "$_HOLD_LABEL" = "true" ]; then
-            echo "::error::PR has banned label: hold"
+            echo "::error::PR has banned label: hold" | tee -a $GITHUB_STEP_SUMMARY
             exit 1
           fi
           if [ "$_NEEDS_QA_LABEL" = "true" ]; then
-            echo "::error::PR has banned label: needs-qa"
+            echo "::error::PR has banned label: needs-qa" | tee -a $GITHUB_STEP_SUMMARY
             exit 1
           fi
-          echo "✅ No banned labels found."
+          echo "✅ No banned labels found." | tee -a $GITHUB_STEP_SUMMARY
 
       - name: Enforce exactly one Change Type (t:*) label
         env:
-          _PR_ACTION: ${{ github.event.action }}
-          _PR_LABELS: ${{ toJSON(github.event.pull_request.labels) }}
+          _PR_ACTION: ${{ inputs.test_pr_labels_json != '' && 'labeled' || github.event.action }}
+          _PR_LABELS: ${{ inputs.test_pr_labels_json != '' && inputs.test_pr_labels_json || toJSON(github.event.pull_request.labels) }}
           _REPO: ${{ github.repository }}
           _PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ github.token }}
@@ -45,21 +52,20 @@ jobs:
           fi
           _IGNORE_FOR_RELEASE_LABEL=$(echo "$_PR_LABELS" | jq 'any(.[]; .name == "ignore-for-release")')
           if [ "$_IGNORE_FOR_RELEASE_LABEL" = "true" ]; then
-            echo "⏭️ Skipping type label check - 'ignore-for-release' label present"
+            echo "⏭️ Skipping type label check - \`ignore-for-release\` label present" | tee -a $GITHUB_STEP_SUMMARY
             exit 0
           fi
           _T_LABEL_COUNT=$(echo "$_PR_LABELS" | jq '[.[] | select(.name | startswith("t:"))] | length')
           case "$_T_LABEL_COUNT" in
             1)
-              echo "✅ PR has exactly one Change Type (t:*) label"
+              echo "✅ PR has exactly one Change Type (t:*) label" | tee -a $GITHUB_STEP_SUMMARY
               ;;
             0)
-              echo "::error::PR is missing a Change Type (t:*) label. PRs must have exactly one Change Type (t:*) label"
+              echo "::error::PR is missing a Change Type (t:*) label. PRs must have exactly one Change Type (t:*) label" | tee -a $GITHUB_STEP_SUMMARY
               exit 1
               ;;
             *)
-              echo "::error::PR has $_T_LABEL_COUNT Change Type (t:*) labels. PRs must have exactly one Change Type (t:*) label"
+              echo "::error::PR has $_T_LABEL_COUNT Change Type (t:*) labels. PRs must have exactly one Change Type (t:*) label" | tee -a $GITHUB_STEP_SUMMARY
               exit 1
               ;;
           esac
-

--- a/.github/workflows/_enforce-pr-labels-sdlc.yml
+++ b/.github/workflows/_enforce-pr-labels-sdlc.yml
@@ -27,11 +27,11 @@ jobs:
           _NEEDS_QA_LABEL: ${{ inputs.test_pr_labels_json != '' && contains(fromJSON(inputs.test_pr_labels_json).*.name, 'needs-qa') || contains(github.event.pull_request.labels.*.name, 'needs-qa') }}
         run: |
           if [ "$_HOLD_LABEL" = "true" ]; then
-            echo "::error::PR has banned label: hold" | tee -a $GITHUB_STEP_SUMMARY
+            echo ":x: PR has banned label: hold" | tee -a $GITHUB_STEP_SUMMARY
             exit 1
           fi
           if [ "$_NEEDS_QA_LABEL" = "true" ]; then
-            echo "::error::PR has banned label: needs-qa" | tee -a $GITHUB_STEP_SUMMARY
+            echo ":x: PR has banned label: needs-qa" | tee -a $GITHUB_STEP_SUMMARY
             exit 1
           fi
           echo "✅ No banned labels found." | tee -a $GITHUB_STEP_SUMMARY
@@ -61,11 +61,11 @@ jobs:
               echo "✅ PR has exactly one Change Type (t:*) label" | tee -a $GITHUB_STEP_SUMMARY
               ;;
             0)
-              echo "::error::PR is missing a Change Type (t:*) label. PRs must have exactly one Change Type (t:*) label" | tee -a $GITHUB_STEP_SUMMARY
+              echo ":error: PR is missing a Change Type (t:*) label. PRs must have exactly one Change Type (t:*) label" | tee -a $GITHUB_STEP_SUMMARY
               exit 1
               ;;
             *)
-              echo "::error::PR has $_T_LABEL_COUNT Change Type (t:*) labels. PRs must have exactly one Change Type (t:*) label" | tee -a $GITHUB_STEP_SUMMARY
+              echo ":error: PR has $_T_LABEL_COUNT Change Type (t:*) labels. PRs must have exactly one Change Type (t:*) label" | tee -a $GITHUB_STEP_SUMMARY
               exit 1
               ;;
           esac

--- a/.github/workflows/_enforce-pr-labels-sdlc.yml
+++ b/.github/workflows/_enforce-pr-labels-sdlc.yml
@@ -2,8 +2,6 @@ name: SDLC / Enforce PR labels
 run-name: Enforce labels for PR ${{ github.event.pull_request.number }}
 
 on:
-  pull_request:
-    types: [labeled, unlabeled, opened, reopened, edited, synchronize]
   workflow_call:
     inputs:
       test_pr_labels_json:

--- a/.github/workflows/test-enforce-pr-labels-sdlc.yml
+++ b/.github/workflows/test-enforce-pr-labels-sdlc.yml
@@ -88,9 +88,9 @@ jobs:
             local result="$2"
             local expected="$3"
             if [[ "$result" == "$expected" ]]; then
-              echo "SUCCESS: [$name] correctly got [$result]" | tee -a $GITHUB_STEP_SUMMARY
+              echo "✅ [$name] correctly got [$result]" | tee -a $GITHUB_STEP_SUMMARY
             else
-              echo "ERROR: [$name] expected [$expected] but got [$result]" | tee -a $GITHUB_STEP_SUMMARY
+              echo ":x: [$name] expected [$expected] but got [$result]" | tee -a $GITHUB_STEP_SUMMARY
               failed=true
             fi
           }
@@ -103,7 +103,7 @@ jobs:
           check_result "test-invalid-needs-qa-label"    "$_INVALID_NEEDS_QA_LABEL"    "failure"
 
           if [[ "$failed" == "true" ]]; then
-            echo "::error::One or more test results were unexpected. See above for details." | tee -a $GITHUB_STEP_SUMMARY
+            echo ":x: One or more test results were unexpected. See above for details." | tee -a $GITHUB_STEP_SUMMARY
             exit 1
           fi
 

--- a/.github/workflows/test-enforce-pr-labels-sdlc.yml
+++ b/.github/workflows/test-enforce-pr-labels-sdlc.yml
@@ -1,0 +1,110 @@
+name: Test SDLC / Enforce PR labels workflow
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/_enforce-pr-labels-sdlc.yml"
+      - ".github/workflows/test-enforce-pr-labels-sdlc.yml"
+
+permissions: {}
+
+jobs:
+  test-valid-one-t-label:
+    name: Test valid - one t:* label (should pass)
+    uses: ./.github/workflows/_enforce-pr-labels-sdlc.yml
+    with:
+      test_pr_labels_json: '[{"name":"t:bug"}]'
+    permissions:
+      pull-requests: read
+
+  test-valid-ignore-for-release:
+    name: Test valid - ignore-for-release label (should pass)
+    uses: ./.github/workflows/_enforce-pr-labels-sdlc.yml
+    with:
+      test_pr_labels_json: '[{"name":"ignore-for-release"}]'
+    permissions:
+      pull-requests: read
+
+  test-invalid-no-t-label:
+    name: Test invalid - no t:* label (should fail)
+    uses: ./.github/workflows/_enforce-pr-labels-sdlc.yml
+    with:
+      test_pr_labels_json: '[]'
+    permissions:
+      pull-requests: read
+
+  test-invalid-multiple-t-labels:
+    name: Test invalid - multiple t:* labels (should fail)
+    uses: ./.github/workflows/_enforce-pr-labels-sdlc.yml
+    with:
+      test_pr_labels_json: '[{"name":"t:bug"},{"name":"t:feature"}]'
+    permissions:
+      pull-requests: read
+
+  test-invalid-hold-label:
+    name: Test invalid - hold label (should fail)
+    uses: ./.github/workflows/_enforce-pr-labels-sdlc.yml
+    with:
+      test_pr_labels_json: '[{"name":"hold"},{"name":"t:bug"}]'
+    permissions:
+      pull-requests: read
+
+  test-invalid-needs-qa-label:
+    name: Test invalid - needs-qa label (should fail)
+    uses: ./.github/workflows/_enforce-pr-labels-sdlc.yml
+    with:
+      test_pr_labels_json: '[{"name":"needs-qa"},{"name":"t:bug"}]'
+    permissions:
+      pull-requests: read
+
+  validate:
+    name: Validate Test Results
+    runs-on: ubuntu-24.04
+    needs:
+      - test-valid-one-t-label
+      - test-valid-ignore-for-release
+      - test-invalid-no-t-label
+      - test-invalid-multiple-t-labels
+      - test-invalid-hold-label
+      - test-invalid-needs-qa-label
+    if: always()
+    permissions:
+      contents: read
+    env:
+      _VALID_ONE_T_LABEL: ${{ needs.test-valid-one-t-label.result }}
+      _VALID_IGNORE_FOR_RELEASE: ${{ needs.test-valid-ignore-for-release.result }}
+      _INVALID_NO_T_LABEL: ${{ needs.test-invalid-no-t-label.result }}
+      _INVALID_MULTIPLE_T_LABELS: ${{ needs.test-invalid-multiple-t-labels.result }}
+      _INVALID_HOLD_LABEL: ${{ needs.test-invalid-hold-label.result }}
+      _INVALID_NEEDS_QA_LABEL: ${{ needs.test-invalid-needs-qa-label.result }}
+    steps:
+      - name: Validate results
+        run: |
+          failed=false
+
+          check_result() {
+            local name="$1"
+            local result="$2"
+            local expected="$3"
+            if [[ "$result" == "$expected" ]]; then
+              echo "SUCCESS: [$name] correctly got [$result]" | tee -a $GITHUB_STEP_SUMMARY
+            else
+              echo "ERROR: [$name] expected [$expected] but got [$result]" | tee -a $GITHUB_STEP_SUMMARY
+              failed=true
+            fi
+          }
+
+          check_result "test-valid-one-t-label"         "$_VALID_ONE_T_LABEL"         "success"
+          check_result "test-valid-ignore-for-release"  "$_VALID_IGNORE_FOR_RELEASE"  "success"
+          check_result "test-invalid-no-t-label"        "$_INVALID_NO_T_LABEL"        "failure"
+          check_result "test-invalid-multiple-t-labels" "$_INVALID_MULTIPLE_T_LABELS" "failure"
+          check_result "test-invalid-hold-label"        "$_INVALID_HOLD_LABEL"        "failure"
+          check_result "test-invalid-needs-qa-label"    "$_INVALID_NEEDS_QA_LABEL"    "failure"
+
+          if [[ "$failed" == "true" ]]; then
+            echo "::error::One or more test results were unexpected. See above for details." | tee -a $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
+          echo "✅ All test results are as expected." | tee -a $GITHUB_STEP_SUMMARY

--- a/enforce-pr-labels-sdlc/README.md
+++ b/enforce-pr-labels-sdlc/README.md
@@ -27,6 +27,7 @@ permissions: {}
 
 jobs:
   enforce-label:
+    name: Enforce Label
     uses: bitwarden/gh-actions/.github/workflows/_enforce-pr-labels-sdlc.yml@main
     permissions:
       pull-requests: read

--- a/enforce-pr-labels-sdlc/README.md
+++ b/enforce-pr-labels-sdlc/README.md
@@ -1,0 +1,128 @@
+# Enforce PR Labels SDLC Reusable Workflow
+
+## Description
+The `_enforce-pr-labels-sdlc.yml` reusable workflow enforces labeling requirements on pull requests as part of the SDLC process. It triggers automatically on PR label changes and other PR events to ensure every PR has exactly one Change Type (`t:*`) label and does not carry any banned labels (e.g. `hold`, `needs-qa`).
+
+## Key Features
+- **Banned Label Enforcement**: Fails immediately if `hold` or `needs-qa` labels are present on the PR
+- **Change Type Enforcement**: Ensures every PR has exactly one `t:*` label before merging
+- **Labeler Grace Period**: On `opened`/`reopened` events, waits 15 seconds for automated labelers to apply labels before checking
+- **Release Escape Hatch**: PRs labeled `ignore-for-release` skip the Change Type check entirely
+- **Automatic Triggering**: Runs on all relevant PR events: `labeled`, `unlabeled`, `opened`, `reopened`, `edited`, `synchronize`
+
+## How to use it
+
+### Setup
+Copy the following caller workflow into your repository's `.github/workflows/` directory and call the reusable workflow:
+
+```yaml
+name: SDLC / Enforce PR labels
+run-name: Enforce labels for PR ${{ github.event.pull_request.number }}
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, reopened, edited, synchronize]
+
+permissions: {}
+
+jobs:
+  enforce-label:
+    uses: bitwarden/gh-actions/.github/workflows/_enforce-pr-labels-sdlc.yml@main
+    permissions:
+      pull-requests: read
+```
+
+### Label Requirements
+For a PR to pass this check, it must:
+1. **Not** have the `hold` label
+2. **Not** have the `needs-qa` label
+3. Have **exactly one** `t:*` label (e.g. `t:bug`, `t:enhancement`, `t:refactor`)
+   - Unless it has the `ignore-for-release` label, in which case the `t:*` check is skipped
+
+## Workflow Diagram
+```mermaid
+flowchart TB
+    subgraph Trigger["Triggering Event"]
+        A[pull_request event<br/>labeled / unlabeled / opened<br/>reopened / edited / synchronize]
+    end
+
+    subgraph BannedCheck["Step 1: Banned Labels"]
+        B1{hold label<br/>present?}
+        B2{needs-qa label<br/>present?}
+        B3[✅ No banned labels]
+        B4[❌ Error: banned label 'hold']
+        B5[❌ Error: banned label 'needs-qa']
+    end
+
+    subgraph TypeCheck["Step 2: Change Type Label"]
+        C1{Event is opened<br/>or reopened?}
+        C2[⏳ Wait 15s for<br/>labeler to run]
+        C3[Re-fetch labels via gh CLI]
+        C4{ignore-for-release<br/>label present?}
+        C5[⏭️ Skip type check]
+        C6{Count of t:* labels}
+        C7[✅ Exactly one t:* label]
+        C8[❌ Error: missing t:* label]
+        C9[❌ Error: multiple t:* labels]
+    end
+
+    subgraph Result["Result"]
+        D1[✅ PR passes label enforcement]
+    end
+
+    A --> B1
+    B1 -->|Yes| B4
+    B1 -->|No| B2
+    B2 -->|Yes| B5
+    B2 -->|No| B3
+    B3 --> C1
+
+    C1 -->|Yes| C2
+    C1 -->|No| C4
+    C2 --> C3
+    C3 --> C4
+
+    C4 -->|Yes| C5
+    C4 -->|No| C6
+
+    C6 -->|= 1| C7
+    C6 -->|= 0| C8
+    C6 -->|> 1| C9
+
+    C5 --> D1
+    C7 --> D1
+
+    style Trigger fill:#e1f5ff
+    style BannedCheck fill:#fff4e1
+    style TypeCheck fill:#e8f5e9
+    style Result fill:#f3e5f5
+    style B4 fill:#ffcdd2
+    style B5 fill:#ffcdd2
+    style C8 fill:#ffcdd2
+    style C9 fill:#ffcdd2
+    style C5 fill:#fff9c4
+```
+
+## Requirements
+- The repository must have `t:*` labels created (e.g. `t:bug`, `t:enhancement`, `t:refactor`, etc.)
+- PRs targeting release/hotfix flows that should bypass type checking must use the `ignore-for-release` label
+
+## Troubleshooting
+
+### "PR has banned label: hold" error
+- The `hold` label must be removed before the PR can be merged
+- This label is typically applied to signal that a PR should not be merged yet
+- Remove the label once the hold condition is resolved
+
+### "PR has banned label: needs-qa" error
+- The `needs-qa` label must be removed before the PR can be merged
+- Ensure QA sign-off has been completed and the label has been removed
+
+### "PR is missing a Change Type (t:*) label" error
+- Add exactly one `t:*` label to the PR (e.g. `t:bug`, `t:enhancement`)
+- On `opened`/`reopened` events the workflow waits 15 seconds for an automated labeler — if the labeler did not apply a label, add one manually
+- If the PR should be excluded from release tracking entirely, add the `ignore-for-release` label
+
+### "PR has N Change Type (t:*) labels" error
+- Remove extra `t:*` labels until exactly one remains
+- Each PR should represent one type of change

--- a/enforce-pr-labels-sdlc/enforce-pr-labels-sdlc.yml
+++ b/enforce-pr-labels-sdlc/enforce-pr-labels-sdlc.yml
@@ -1,0 +1,15 @@
+name: SDLC / Enforce PR labels
+run-name: Enforce labels for PR ${{ github.event.pull_request.number }}
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, reopened, edited, synchronize]
+
+permissions: {}
+
+jobs:
+  enforce-label:
+    name: Enforce Label
+    uses: bitwarden/gh-actions/.github/workflows/_enforce-pr-labels-sdlc.yml@main
+    permissions:
+      pull-requests: read


### PR DESCRIPTION
## 🎟️ Tracking
[BRE-1809](https://bitwarden.atlassian.net/browse/BRE-1809)

## 📔 Objective
The Dev teams use copies of this workflow across different repos to enforce a standard set of PR labels. This PR centralizes the workflow in `gh-actions`. It includes all the requirements outlined [here](https://bitwarden.atlassian.net/wiki/x/CgAukg)

### Files
`_enforce-pr-labels-sdlc.yml`
This is the reusable workflow. Here is its purpose, pulled from the README:
- **Banned Label Enforcement**: Fails immediately if `hold` or `needs-qa` labels are present on the PR
- **Change Type Enforcement**: Ensures every PR has exactly one `t:*` (type) label before merging
---

`enforce-pr-labels-sdlc.yml`
This is the template/stub workflow that users will copy into the calling repos

---

`test_enforce-pr-labels-sdlc.yml`
This is the test workflow that will run on any open PRs that change the reusable workflow

---

`README.md`
The standard README

## 🚨 Breaking Changes
None, workflow isn't in production use yet.

[BRE-1809]: https://bitwarden.atlassian.net/browse/BRE-1809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ