### PR TITLE
disable checkmarx scanning

### DIFF
--- a/.github/workflows/_checkmarx.yml
+++ b/.github/workflows/_checkmarx.yml
@@ -13,11 +13,11 @@ on:
         default: true
     secrets:
       AZURE_SUBSCRIPTION_ID:
-        required: true
+        required: false
       AZURE_TENANT_ID:
-        required: true
+        required: false
       AZURE_CLIENT_ID:
-        required: true
+        required: false
 
 concurrency:
   group: ${{ github.repository }}-${{ github.workflow }}-checkmarx-${{ github.event.pull_request.number || github.head_ref || github.ref }}
@@ -31,52 +31,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      pull-requests: write
-      security-events: write
-      id-token: write
 
     steps:
-      - name: Check out repo
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          persist-credentials: false
-
-      - name: Log in to Azure
-        uses: bitwarden/gh-actions/azure-login@main
-        with:
-          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
-          client_id: ${{ secrets.AZURE_CLIENT_ID }}
-
-      - name: Get Azure Key Vault secrets
-        id: get-kv-secrets
-        uses: bitwarden/gh-actions/get-keyvault-secrets@main
-        with:
-          keyvault: gh-org-bitwarden
-          secrets: "CHECKMARX-TENANT,CHECKMARX-CLIENT-ID,CHECKMARX-SECRET"
-
-      - name: Log out from Azure
-        uses: bitwarden/gh-actions/azure-logout@main
-
-      - name: Scan with Checkmarx
-        uses: checkmarx/ast-github-action@c52fa63dbd4916520882e10456d66ff4dd7bf754 # 2.3.33
-        with:
-          project_name: ${{ github.repository }}
-          cx_tenant: ${{ steps.get-kv-secrets.outputs.CHECKMARX-TENANT }}
-          base_uri: https://ast.checkmarx.net/
-          cx_client_id: ${{ steps.get-kv-secrets.outputs.CHECKMARX-CLIENT-ID }}
-          cx_client_secret: ${{ steps.get-kv-secrets.outputs.CHECKMARX-SECRET  }}
-          additional_params: >-
-            --report-format sarif
-            --filter "state=TO_VERIFY;PROPOSED_NOT_EXPLOITABLE;CONFIRMED;URGENT"
-            --output-path .
-            ${{ case(inputs.incremental, '--sast-incremental', '') }}
-
-      - name: Upload Checkmarx results to GitHub
-        if: inputs.upload-sarif
-        uses: github/codeql-action/upload-sarif@19b2f06db2b6f5108140aeb04014ef02b648f789 # v4.31.11
-        with:
-          sarif_file: cx_result.sarif
-          sha: ${{ case(contains(github.event_name, 'pull_request'), github.event.pull_request.head.sha, github.sha) }}
-          ref: ${{ case(contains(github.event_name, 'pull_request'), format('refs/pull/{0}/head', github.event.pull_request.number), github.ref) }}
+      - name: Checkmarx scanning disabled
+        run: echo "Checkmarx scanning has been disabled."


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

replace checkmarx calls with stub. this will prevent noise and failures across the codebase until it can be properly removed across repos