### PR TITLE
Added timestamp to trigger-artifact to prevent collisions

### DIFF
--- a/trigger-actions/action.yml
+++ b/trigger-actions/action.yml
@@ -58,16 +58,19 @@ runs:
         repositories: ${{ steps.retrieve-secrets.outputs.TRIGGER-REPO-NAME }}
         permission-deployments: write
 
+    - name: Set trigger context filename
+      shell: bash
+      run: |
+        _TS="$(date +%s%3N)"
+        echo "TRIGGER_CONTEXT_FILE=trigger-context-${_TS}.json" >> "$GITHUB_ENV"
+        echo "TRIGGER_CONTEXT_ARTIFACT=trigger-context-${_TS}" >> "$GITHUB_ENV"
+
     - name: Write trigger context
       shell: bash
       env:
         _INPUTS: ${{ toJSON(github.event.inputs) }}
         _DATA: ${{ inputs.data }}
-        TRIGGER_CONTEXT_FILE: trigger-context.json
-        TRIGGER_CONTEXT_ARTIFACT: trigger-context
       run: |
-        echo "TRIGGER_CONTEXT_FILE=$TRIGGER_CONTEXT_FILE" >> "$GITHUB_ENV"
-        echo "TRIGGER_CONTEXT_ARTIFACT=$TRIGGER_CONTEXT_ARTIFACT" >> "$GITHUB_ENV"
         if [[ -n "$_DATA" ]] && ! echo "$_DATA" | jq empty 2>/dev/null; then
           echo "::error::custom-data must be a valid JSON value"
           exit 1


### PR DESCRIPTION
## 🎟️ Tracking

[failed run](https://github.com/bitwarden/billing-relay/actions/runs/25503650880/job/74843680345#step:3:1)

## 📔 Objective

When the `trigger-actions` action is run multiple times in a single run, it attempts to upload the `trigger-context` artifact multiple times using the same name, causing conflicts. This PR adds a millisecond-level timestamp to the `trigger-context` filename to prevent collisions. 

