### PR TITLE
[BRE-1871] Monitor deploy status to provide feedback

### DIFF
--- a/.github/workflows/test-trigger-actions.yml
+++ b/.github/workflows/test-trigger-actions.yml
@@ -26,6 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Run trigger-actions
+        id: trigger
         uses: ./trigger-actions
         with:
           azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -34,32 +35,24 @@ jobs:
           task: test-trigger-actions
           data: '{"test": true}'
           test: "true"
-
-      - name: Verify deployment was created
-        id: verify
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPOSITORY: ${{ github.repository }}
-        run: |
-          DEPLOYMENT_ID=$(gh api "repos/$REPOSITORY/deployments?task=test-trigger-actions&per_page=1" \
-            --jq '.[0].id // empty')
-
-          if [[ -z "$DEPLOYMENT_ID" ]]; then
-            echo "::error::No deployment found with task=test-trigger-actions"
-            exit 1
-          fi
-
-          echo "deployment_id=$DEPLOYMENT_ID" >> "$GITHUB_OUTPUT"
-          echo "Deployment created successfully with ID: $DEPLOYMENT_ID"
+          # The simulate-downstream job (running in parallel) drives this
+          # deployment to `success` within ~30-45s. 3 minutes is the safety net.
+          monitor-timeout-minutes: "3"
 
       - name: Verify deployment payload
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
-          DEPLOYMENT_ID: ${{ steps.verify.outputs.deployment_id }}
+          DEPLOYMENT_ID: ${{ steps.trigger.outputs.deployment-id }}
           EXPECTED_RUN_ID: ${{ github.run_id }}
           EXPECTED_SHA: ${{ github.sha }}
         run: |
+          if [[ -z "$DEPLOYMENT_ID" ]]; then
+            echo "::error::trigger-actions did not output deployment-id"
+            exit 1
+          fi
+          echo "deployment-id from composite output: $DEPLOYMENT_ID"
+
           PAYLOAD=$(gh api "repos/$REPOSITORY/deployments/$DEPLOYMENT_ID" --jq '.payload')
 
           RUN_ID=$(echo "$PAYLOAD" | jq -r '.run.id')
@@ -136,3 +129,59 @@ jobs:
               --method DELETE
             echo "Deleted deployment $ID"
           done
+
+  simulate-downstream:
+    name: Simulate Downstream Success
+    runs-on: ubuntu-24.04
+    permissions:
+      deployments: write
+    steps:
+      - name: Find the deployment created by the test job
+        id: find
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          # Poll up to 30 times (5s each = 150s budget) for the deployment
+          # whose payload.run.id matches the current workflow run.
+          for i in $(seq 1 30); do
+            DEPLOYMENT_ID=$(gh api \
+              "repos/$REPOSITORY/deployments?environment=trigger-actions&task=test-trigger-actions&per_page=30" \
+              --jq "[.[] | select(.payload.run.id == ${RUN_ID}) | .id][0] // empty")
+            if [[ -n "$DEPLOYMENT_ID" ]]; then
+              echo "Found deployment $DEPLOYMENT_ID for run $RUN_ID (after $((i * 5))s)"
+              echo "deployment_id=$DEPLOYMENT_ID" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::Did not find a trigger-actions deployment from run $RUN_ID within 150s"
+          exit 1
+
+      - name: Post in_progress status
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          DEPLOYMENT_ID: ${{ steps.find.outputs.deployment_id }}
+        run: |
+          gh api "repos/$REPOSITORY/deployments/$DEPLOYMENT_ID/statuses" \
+            --method POST \
+            -f state=in_progress \
+            -f description="Simulated: downstream started"
+          echo "Posted in_progress on deployment $DEPLOYMENT_ID"
+
+      - name: Wait so the monitor logs the in_progress status
+        run: sleep 15
+
+      - name: Post success status
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          DEPLOYMENT_ID: ${{ steps.find.outputs.deployment_id }}
+        run: |
+          gh api "repos/$REPOSITORY/deployments/$DEPLOYMENT_ID/statuses" \
+            --method POST \
+            -f state=success \
+            -f description="Simulated: downstream completed"
+          echo "Posted success on deployment $DEPLOYMENT_ID"

--- a/trigger-actions/README.md
+++ b/trigger-actions/README.md
@@ -24,7 +24,7 @@ Receiving repositories should have a workflow triggered on `deployment` that fil
 | `azure_subscription_id` | Yes | | Azure Subscription ID for OIDC login |
 | `azure_tenant_id` | Yes | | Azure Tenant ID for OIDC login |
 | `azure_client_id` | Yes | | Azure Client ID for OIDC login |
-| `task` | Yes | | Task name used for routing. Also determines the target repository (`deploy-server-dev` → `devops`, all others → `deploy`) |
+| `task` | Yes | | Task name used for routing in the target repository |
 | `description` | No | *(task value)* | Human-readable description of the trigger. Defaults to the `task` value if not provided |
 | `monitor-timeout-minutes` | No | `10` | How long to wait for the downstream deployment to reach a terminal status |
 | `monitor-poll-interval-seconds` | No | `10` | How often to poll the deployment for status updates |

--- a/trigger-actions/README.md
+++ b/trigger-actions/README.md
@@ -13,8 +13,9 @@ This decouples the caller from knowledge of what workflow runs downstream — th
 1. Authenticates to Azure via OIDC and retrieves the GitHub App credentials (`GH-TRIGGER-APP-ID`, `GH-TRIGGER-APP-KEY`) from the `gh-org-bitwarden` Key Vault
 2. Mints a short-lived GitHub App token scoped to the target repository with `deployments: write`
 3. Creates a deployment event on `main` of the target repository with `environment: trigger-actions` and the provided `task`
+4. Polls the deployment's status history every `monitor-poll-interval-seconds` until it reaches a terminal state (`success` / `failure` / `error`) or `monitor-timeout-minutes` elapses. Each new status is logged with its timestamp. The action exits successfully on `success`, fails on `failure` / `error`, and fails on timeout.
 
-Receiving repositories should have a workflow triggered on `deployment` that filters on both `github.event.deployment.environment == 'trigger-actions'` and `github.event.deployment.task == '<task-name>'`.
+Receiving repositories should have a workflow triggered on `deployment` that filters on both `github.event.deployment.environment == 'trigger-actions'` and `github.event.deployment.task == '<task-name>'`. Downstream workflows must call `createDeploymentStatus` on this deployment to drive the monitoring loop; without those updates, the action will always time out.
 
 ## Inputs
 
@@ -25,6 +26,8 @@ Receiving repositories should have a workflow triggered on `deployment` that fil
 | `azure_client_id` | Yes | | Azure Client ID for OIDC login |
 | `task` | Yes | | Task name used for routing. Also determines the target repository (`deploy-server-dev` → `devops`, all others → `deploy`) |
 | `description` | No | *(task value)* | Human-readable description of the trigger. Defaults to the `task` value if not provided |
+| `monitor-timeout-minutes` | No | `10` | How long to wait for the downstream deployment to reach a terminal status |
+| `monitor-poll-interval-seconds` | No | `10` | How often to poll the deployment for status updates |
 | `test` | No | `false` | Skip App token generation and use the calling workflow's token instead. For testing only |
 
 ## Usage

--- a/trigger-actions/README.md
+++ b/trigger-actions/README.md
@@ -50,3 +50,9 @@ Receiving repositories should have a workflow triggered on `deployment` that fil
 - `GH-TRIGGER-APP-ID` and `GH-TRIGGER-APP-KEY` must be present in the `gh-org-bitwarden` Key Vault
 - The GitHub App must be installed on the target repository with `deployments: write`
 - The target repository must have a workflow listening on the `deployment` event that handles the `trigger-actions` environment and the relevant `task` value
+
+## Receiving side
+
+The target repository today is `bitwarden/deploy`. Its receiving workflow is `.github/workflows/trigger-actions.yml`, which routes each deployment event by `task` to a dedicated job that dispatches the actual deploy/publish workflow and reports status back here.
+
+For the list of supported task names, the architectural overview, and how to add a new task or caller, see [`bitwarden/deploy` → docs/trigger-actions.md](https://github.com/bitwarden/deploy/blob/main/docs/trigger-actions.md).

--- a/trigger-actions/README.md
+++ b/trigger-actions/README.md
@@ -26,6 +26,7 @@ Receiving repositories should have a workflow triggered on `deployment` that fil
 | `azure_client_id` | Yes | | Azure Client ID for OIDC login |
 | `task` | Yes | | Task name used for routing in the target repository |
 | `description` | No | *(task value)* | Human-readable description of the trigger. Defaults to the `task` value if not provided |
+| `monitor-deployment` | No | `true` | Whether to poll the deployment for status updates after creating it. Set to `false` to fire-and-forget |
 | `monitor-timeout-minutes` | No | `10` | How long to wait for the downstream deployment to reach a terminal status |
 | `monitor-poll-interval-seconds` | No | `10` | How often to poll the deployment for status updates |
 | `test` | No | `false` | Skip App token generation and use the calling workflow's token instead. For testing only |

--- a/trigger-actions/action.yml
+++ b/trigger-actions/action.yml
@@ -193,8 +193,10 @@ runs:
           const timeoutMs = timeoutMinutes * 60 * 1000;
           const pollIntervalMs = pollIntervalSeconds * 1000;
           const terminalStates = ['success', 'failure', 'error'];
+          const MAX_CONSECUTIVE_ERRORS = 5;
           const startTime = Date.now();
           let lastSeenAt = null;
+          let consecutiveErrors = 0;
 
           core.info(`Monitoring deployment ${owner}/${repo}#${deploymentId}`);
           core.info(`  environment: ${environment}`);
@@ -209,12 +211,27 @@ runs:
               return;
             }
 
-            const { data: statuses } = await github.rest.repos.listDeploymentStatuses({
-              owner,
-              repo,
-              deployment_id: deploymentId,
-              per_page: 1,
-            });
+            let statuses;
+            try {
+              const response = await github.rest.repos.listDeploymentStatuses({
+                owner,
+                repo,
+                deployment_id: deploymentId,
+                per_page: 1,
+              });
+              statuses = response.data;
+              consecutiveErrors = 0;
+            } catch (e) {
+              consecutiveErrors++;
+              const status = e.status || 'unknown';
+              if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+                core.setFailed(`Failed to query deployment statuses ${consecutiveErrors} times in a row (last error: ${status} ${e.message})`);
+                return;
+              }
+              core.warning(`Transient error querying deployment statuses (${consecutiveErrors}/${MAX_CONSECUTIVE_ERRORS}): ${status} ${e.message}`);
+              await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+              continue;
+            }
 
             if (statuses.length > 0) {
               const latest = statuses[0];

--- a/trigger-actions/action.yml
+++ b/trigger-actions/action.yml
@@ -157,6 +157,8 @@ runs:
         DEPLOYMENT_ID: ${{ steps.create-deployment.outputs.deployment-id }}
         DEPLOYMENT_OWNER: ${{ steps.create-deployment.outputs.deployment-owner }}
         DEPLOYMENT_REPO: ${{ steps.create-deployment.outputs.deployment-repo }}
+        DEPLOYMENT_TASK: ${{ inputs.task }}
+        DEPLOYMENT_ENVIRONMENT: trigger-actions
         TIMEOUT_MINUTES: ${{ inputs.monitor-timeout-minutes }}
         POLL_INTERVAL_SECONDS: ${{ inputs.monitor-poll-interval-seconds }}
       with:
@@ -165,6 +167,8 @@ runs:
           const deploymentId = Number(process.env.DEPLOYMENT_ID);
           const owner = process.env.DEPLOYMENT_OWNER;
           const repo = process.env.DEPLOYMENT_REPO;
+          const task = process.env.DEPLOYMENT_TASK;
+          const environment = process.env.DEPLOYMENT_ENVIRONMENT;
           const timeoutMinutes = Number(process.env.TIMEOUT_MINUTES);
           const pollIntervalSeconds = Number(process.env.POLL_INTERVAL_SECONDS);
 
@@ -181,7 +185,11 @@ runs:
           const startTime = Date.now();
           let lastSeenAt = null;
 
-          core.info(`Monitoring deployment ${owner}/${repo}#${deploymentId} (timeout: ${timeoutMinutes}m, poll: ${pollIntervalSeconds}s)`);
+          core.info(`Monitoring deployment ${owner}/${repo}#${deploymentId}`);
+          core.info(`  environment: ${environment}`);
+          core.info(`  task:        ${task}`);
+          core.info(`  timeout:     ${timeoutMinutes}m`);
+          core.info(`  poll:        ${pollIntervalSeconds}s`);
 
           while (true) {
             const elapsedMs = Date.now() - startTime;

--- a/trigger-actions/action.yml
+++ b/trigger-actions/action.yml
@@ -26,6 +26,25 @@ inputs:
     description: "Skip GitHub App token generation and use the calling workflow's token instead (for testing only)"
     required: false
     default: "false"
+  monitor-timeout-minutes:
+    description: "How long to wait for the downstream deployment to reach a terminal status (success / failure / error), in minutes."
+    required: false
+    default: "10"
+  monitor-poll-interval-seconds:
+    description: "How often to poll the downstream deployment for status updates, in seconds."
+    required: false
+    default: "10"
+
+outputs:
+  deployment-id:
+    description: "ID of the deployment created on the target repository"
+    value: ${{ steps.create-deployment.outputs.deployment-id }}
+  deployment-owner:
+    description: "Owner of the target repository (always `bitwarden`)"
+    value: ${{ steps.create-deployment.outputs.deployment-owner }}
+  deployment-repo:
+    description: "Name of the target repository"
+    value: ${{ steps.create-deployment.outputs.deployment-repo }}
 
 runs:
   using: "composite"
@@ -82,6 +101,7 @@ runs:
         path: ${{ env.TRIGGER_CONTEXT_FILE }}
 
     - name: Create deployment
+      id: create-deployment
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       env:
         _REPOSITORY: ${{ inputs.test == 'true' && 'gh-actions' || steps.retrieve-secrets.outputs.TRIGGER-REPO-NAME }}
@@ -115,7 +135,7 @@ runs:
             throw new Error(`Deployment payload size (${payloadSize} chars) exceeds GitHub's limit of ${MAX_PAYLOAD_SIZE} characters`);
           }
 
-          await github.rest.repos.createDeployment({
+          const { data: deployment } = await github.rest.repos.createDeployment({
             owner: 'bitwarden',
             repo: process.env._REPOSITORY,
             ref: 'main',
@@ -125,4 +145,75 @@ runs:
             required_contexts: [],
             description: process.env._DESCRIPTION,
             payload: payload,
-          })
+          });
+          core.setOutput('deployment-id', deployment.id);
+          core.setOutput('deployment-owner', 'bitwarden');
+          core.setOutput('deployment-repo', process.env._REPOSITORY);
+          core.info(`Created deployment ${deployment.id} on bitwarden/${process.env._REPOSITORY}`);
+
+    - name: Monitor deployment
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      env:
+        DEPLOYMENT_ID: ${{ steps.create-deployment.outputs.deployment-id }}
+        DEPLOYMENT_OWNER: ${{ steps.create-deployment.outputs.deployment-owner }}
+        DEPLOYMENT_REPO: ${{ steps.create-deployment.outputs.deployment-repo }}
+        TIMEOUT_MINUTES: ${{ inputs.monitor-timeout-minutes }}
+        POLL_INTERVAL_SECONDS: ${{ inputs.monitor-poll-interval-seconds }}
+      with:
+        github-token: ${{ inputs.test == 'true' && github.token || steps.app-token.outputs.token }}
+        script: |
+          const deploymentId = Number(process.env.DEPLOYMENT_ID);
+          const owner = process.env.DEPLOYMENT_OWNER;
+          const repo = process.env.DEPLOYMENT_REPO;
+          const timeoutMinutes = Number(process.env.TIMEOUT_MINUTES);
+          const pollIntervalSeconds = Number(process.env.POLL_INTERVAL_SECONDS);
+
+          if (!Number.isFinite(timeoutMinutes) || timeoutMinutes <= 0) {
+            throw new Error(`Invalid monitor-timeout-minutes: ${process.env.TIMEOUT_MINUTES}`);
+          }
+          if (!Number.isFinite(pollIntervalSeconds) || pollIntervalSeconds <= 0) {
+            throw new Error(`Invalid monitor-poll-interval-seconds: ${process.env.POLL_INTERVAL_SECONDS}`);
+          }
+
+          const timeoutMs = timeoutMinutes * 60 * 1000;
+          const pollIntervalMs = pollIntervalSeconds * 1000;
+          const terminalStates = ['success', 'failure', 'error'];
+          const startTime = Date.now();
+          let lastSeenAt = null;
+
+          core.info(`Monitoring deployment ${owner}/${repo}#${deploymentId} (timeout: ${timeoutMinutes}m, poll: ${pollIntervalSeconds}s)`);
+
+          while (true) {
+            const elapsedMs = Date.now() - startTime;
+            if (elapsedMs >= timeoutMs) {
+              core.setFailed(`Timed out after ${timeoutMinutes} minute(s) waiting for deployment ${owner}/${repo}#${deploymentId} to reach a terminal state`);
+              return;
+            }
+
+            const { data: statuses } = await github.rest.repos.listDeploymentStatuses({
+              owner,
+              repo,
+              deployment_id: deploymentId,
+              per_page: 1,
+            });
+
+            if (statuses.length > 0) {
+              const latest = statuses[0];
+              if (latest.created_at !== lastSeenAt) {
+                lastSeenAt = latest.created_at;
+                const desc = latest.description ? ` — ${latest.description}` : '';
+                core.info(`[${latest.created_at}] ${latest.state}${desc}`);
+
+                if (terminalStates.includes(latest.state)) {
+                  if (latest.state === 'success') {
+                    core.info(`Deployment ${owner}/${repo}#${deploymentId} reached terminal state: success`);
+                    return;
+                  }
+                  core.setFailed(`Deployment ${owner}/${repo}#${deploymentId} reached terminal state: ${latest.state}`);
+                  return;
+                }
+              }
+            }
+
+            await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+          }

--- a/trigger-actions/action.yml
+++ b/trigger-actions/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: "Skip GitHub App token generation and use the calling workflow's token instead (for testing only)"
     required: false
     default: "false"
+  monitor-deployment:
+    description: "Whether to poll the downstream deployment for status updates after creating it. Set to `false` to fire-and-forget."
+    required: false
+    default: "true"
   monitor-timeout-minutes:
     description: "How long to wait for the downstream deployment to reach a terminal status (success / failure / error), in minutes."
     required: false
@@ -156,6 +160,7 @@ runs:
           core.info(`Created deployment ${deployment.id} on bitwarden/${process.env._REPOSITORY}`);
 
     - name: Monitor deployment
+      if: inputs.monitor-deployment == 'true'
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       env:
         DEPLOYMENT_ID: ${{ steps.create-deployment.outputs.deployment-id }}

--- a/trigger-actions/action.yml
+++ b/trigger-actions/action.yml
@@ -49,6 +49,10 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Set target repo
+      shell: bash
+      run: echo "TRIGGER_REPO=deploy" >> "$GITHUB_ENV"
+
     - name: Log in to Azure
       uses: bitwarden/gh-actions/azure-login@main
       with:
@@ -69,8 +73,6 @@ runs:
     - name: Generate GitHub App token
       id: app-token
       if: inputs.test != 'true'
-      env:
-        TRIGGER_REPO: deploy
       uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
       with:
         app-id: ${{ steps.retrieve-secrets.outputs.GH-TRIGGER-APP-ID }}
@@ -106,7 +108,7 @@ runs:
       id: create-deployment
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       env:
-        _REPOSITORY: ${{ inputs.test == 'true' && 'gh-actions' || 'deploy' }}
+        _REPOSITORY: ${{ inputs.test == 'true' && 'gh-actions' || env.TRIGGER_REPO }}
         _TASK: ${{ inputs.task }}
         _WORKFLOW_REF: ${{ github.workflow_ref }}
         _DESCRIPTION: "Triggered by ${{ github.event.repository.name }} ${{ github.workflow }} on ${{ github.ref_name }} @ ${{ github.sha }}"

--- a/trigger-actions/action.yml
+++ b/trigger-actions/action.yml
@@ -61,7 +61,7 @@ runs:
       uses: bitwarden/gh-actions/get-keyvault-secrets@main
       with:
         keyvault: gh-org-bitwarden
-        secrets: "GH-TRIGGER-APP-ID,GH-TRIGGER-APP-KEY,TRIGGER-REPO-NAME"
+        secrets: "GH-TRIGGER-APP-ID,GH-TRIGGER-APP-KEY"
 
     - name: Log out from Azure
       uses: bitwarden/gh-actions/azure-logout@main
@@ -69,12 +69,14 @@ runs:
     - name: Generate GitHub App token
       id: app-token
       if: inputs.test != 'true'
+      env:
+        TRIGGER_REPO: deploy
       uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
       with:
         app-id: ${{ steps.retrieve-secrets.outputs.GH-TRIGGER-APP-ID }}
         private-key: ${{ steps.retrieve-secrets.outputs.GH-TRIGGER-APP-KEY }}
         owner: bitwarden
-        repositories: ${{ steps.retrieve-secrets.outputs.TRIGGER-REPO-NAME }}
+        repositories: ${{ env.TRIGGER_REPO }}
         permission-deployments: write
 
     - name: Write trigger context
@@ -104,7 +106,7 @@ runs:
       id: create-deployment
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       env:
-        _REPOSITORY: ${{ inputs.test == 'true' && 'gh-actions' || steps.retrieve-secrets.outputs.TRIGGER-REPO-NAME }}
+        _REPOSITORY: ${{ inputs.test == 'true' && 'gh-actions' || 'deploy' }}
         _TASK: ${{ inputs.task }}
         _WORKFLOW_REF: ${{ github.workflow_ref }}
         _DESCRIPTION: "Triggered by ${{ github.event.repository.name }} ${{ github.workflow }} on ${{ github.ref_name }} @ ${{ github.sha }}"


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-1871](https://bitwarden.atlassian.net/browse/BRE-1871)

## 📔 Objective

Automatically monitor deployment status to provide feedback back to the originating job.

  - Add deployment monitoring to the `trigger-actions` composite: after creating the deployment, poll its status until it reaches a terminal state or times out, with each status update
  logged as it appears
  - Make monitoring opt-out (`monitor-deployment`), with configurable timeout and poll interval
  - Expose the created deployment's identifiers as composite outputs so callers can reference them directly
  - Replace the `TRIGGER-REPO-NAME` keyvault lookup with a single in-action env var
  - Extend the test workflow with a parallel job that drives a deployment to `success`, exercising the full monitoring flow end-to-end

```
Run actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
Created deployment 4663869697 on bitwarden/gh-actions
Run actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
Monitoring deployment bitwarden/gh-actions#4663869697
  environment: trigger-actions
  task:        test-trigger-actions
  timeout:     3m
  poll:        10s
[2026-05-12T16:01:39Z] in_progress — Simulated: downstream started
[2026-05-12T16:01:54Z] success — Simulated: downstream completed
Deployment bitwarden/gh-actions#4663869697 reached terminal state: success
```


Related PRs:
  - https://github.com/bitwarden/deploy/pull/118
  - https://github.com/bitwarden/devops/pull/4680
  - https://github.com/bitwarden/billing-relay/pull/243
  - https://github.com/bitwarden/billing-pricing/pull/112
  - https://github.com/bitwarden/gh-actions/pull/765

[BRE-1871]: https://bitwarden.atlassian.net/browse/BRE-1871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ