### PR TITLE
[bre-1881] trigger actions artifact filename unique naming

### DIFF
--- a/.github/workflows/test-trigger-actions.yml
+++ b/.github/workflows/test-trigger-actions.yml
@@ -53,6 +53,7 @@ jobs:
           echo "Deployment created successfully with ID: $DEPLOYMENT_ID"
 
       - name: Verify deployment payload
+        id: verify-deployment-payload
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
@@ -81,7 +82,13 @@ jobs:
 
           check "run.id" "$RUN_ID" "$EXPECTED_RUN_ID"
           check "run.workflow" "$RUN_WORKFLOW" "test-trigger-actions.yml"
-          check "run.artifact.name" "$ARTIFACT_NAME" "trigger-context"
+
+          if [[ ! "$ARTIFACT_NAME" =~ ^trigger-context(-[a-f0-9]+)?$ ]]; then
+            echo "::error::payload.run.artifact.name: expected pattern 'trigger-context(-[a-f0-9]+)?', got '$ARTIFACT_NAME'"
+            exit 1
+          fi
+          echo "payload.run.artifact.name: ✓ ($ARTIFACT_NAME)"
+
           check "git.sha" "$GIT_SHA" "$EXPECTED_SHA"
           check "git.owner" "$GIT_OWNER" "bitwarden"
           check "git.repo" "$GIT_REPO" "gh-actions"
@@ -92,10 +99,12 @@ jobs:
           fi
           echo "payload.git.branch: ✓ ($GIT_BRANCH)"
 
+          echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+
       - name: Download trigger context artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: trigger-context
+          name: ${{ steps.verify-deployment-payload.outputs.artifact_name }}
           path: trigger-context
 
       - name: Verify trigger context

--- a/trigger-actions/action.yml
+++ b/trigger-actions/action.yml
@@ -58,16 +58,18 @@ runs:
         repositories: ${{ steps.retrieve-secrets.outputs.TRIGGER-REPO-NAME }}
         permission-deployments: write
 
+    - name: Set trigger context artifact name
+      shell: bash
+      run: |
+        echo "TRIGGER_CONTEXT_FILE=trigger-context.json" >> "$GITHUB_ENV"
+        echo "TRIGGER_CONTEXT_ARTIFACT=trigger-context-$(openssl rand -hex 8)" >> "$GITHUB_ENV"
+
     - name: Write trigger context
       shell: bash
       env:
         _INPUTS: ${{ toJSON(github.event.inputs) }}
         _DATA: ${{ inputs.data }}
-        TRIGGER_CONTEXT_FILE: trigger-context.json
-        TRIGGER_CONTEXT_ARTIFACT: trigger-context
       run: |
-        echo "TRIGGER_CONTEXT_FILE=$TRIGGER_CONTEXT_FILE" >> "$GITHUB_ENV"
-        echo "TRIGGER_CONTEXT_ARTIFACT=$TRIGGER_CONTEXT_ARTIFACT" >> "$GITHUB_ENV"
         if [[ -n "$_DATA" ]] && ! echo "$_DATA" | jq empty 2>/dev/null; then
           echo "::error::custom-data must be a valid JSON value"
           exit 1


### PR DESCRIPTION
## 🎟️ Tracking

[bre-1881](https://bitwarden.atlassian.net/browse/bre-1881)

## 📔 Objective

- add unique naming of trigger context artifact for situations like ios CI job where multiple triggger contexts are uploaded to the same run. Example failure this missing caused -> https://github.com/bitwarden/ios/actions/runs/25738936493/job/75583734082#step:28:367
- used this openssl method versus uuidgen or something else so it works across all runner OS types
- related deploy PR -> https://github.com/bitwarden/deploy/pull/103