### PR TITLE
Create workflow to guarantee at least one Claude Code Review per Bitwarden PR

### DIFF
--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -39,55 +39,15 @@ jobs:
       review_variant: ${{ steps.validate.outputs.review_variant }}
 
     steps:
-      - name: Check for review label
-        id: check-label
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "${PR_NUMBER:-}" ]; then
-            echo "label_found=none" >> "$GITHUB_OUTPUT"
-            echo "review_variant=none" >> "$GITHUB_OUTPUT"
-            echo "⚠️ Validation: no pull_request context detected - skipping Claude review"
-            exit 0
-          fi
-
-          LABELS=$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json labels -q '.labels[].name')
-
-          if printf '%s\n' "$LABELS" | grep -Fxq "ai-review-vnext"; then
-            echo "label_found=ai-review-vnext" >> "$GITHUB_OUTPUT"
-            echo "review_variant=vnext" >> "$GITHUB_OUTPUT"
-            echo "✅ Validation: 'ai-review-vnext' label found"
-
-          elif printf '%s\n' "$LABELS" | grep -Fxq "ai-review"; then
-            echo "label_found=ai-review" >> "$GITHUB_OUTPUT"
-            echo "review_variant=current" >> "$GITHUB_OUTPUT"
-            echo "✅ Validation: 'ai-review' label found"
-
-          else
-            echo "label_found=none" >> "$GITHUB_OUTPUT"
-            echo "review_variant=none" >> "$GITHUB_OUTPUT"
-            echo "⚠️ Validation: no review label found - skipping Claude review"
-          fi
-
-      - name: Set validation result
+      - name: Check review gate
         id: validate
-        env:
-          REVIEW_VARIANT: ${{ steps.check-label.outputs.review_variant }}
-        run: |
-          if [ "$REVIEW_VARIANT" != "none" ]; then
-            echo "should_review=true" >> "$GITHUB_OUTPUT"
-            echo "review_variant=$REVIEW_VARIANT" >> "$GITHUB_OUTPUT"
-            echo "✅ Validation passed - code review will proceed (variant: $REVIEW_VARIANT)"
-
-          else
-            echo "should_review=false" >> "$GITHUB_OUTPUT"
-            echo "review_variant=none" >> "$GITHUB_OUTPUT"
-            echo "⚠️ Validation failed - code review will be skipped"
-          fi
+        uses: bitwarden/gh-actions/check-review-gate@main
+        with:
+          event_name: ${{ github.event_name }}
+          marker_id: bitwarden-code-review
+          pr_number: ${{ github.event.pull_request.number }}
+          repository: ${{ github.repository }}
+          token: ${{ github.token }}
 
   review:
     name: Review

--- a/.github/workflows/review-code.yml
+++ b/.github/workflows/review-code.yml
@@ -2,7 +2,7 @@ name: Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [labeled, opened, ready_for_review, reopened, synchronize]
 
 permissions: {}
 

--- a/.github/workflows/test-check-review-gate.yml
+++ b/.github/workflows/test-check-review-gate.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run check-review-gate
         id: gate

--- a/.github/workflows/test-check-review-gate.yml
+++ b/.github/workflows/test-check-review-gate.yml
@@ -39,6 +39,7 @@ jobs:
         uses: ./check-review-gate
         with:
           event_name: ${{ inputs.event_name }}
+          marker_id: bitwarden-code-review
           pr_number: ${{ inputs.pr_number }}
           repository: ${{ github.repository }}
           token: ${{ github.token }}

--- a/.github/workflows/test-check-review-gate.yml
+++ b/.github/workflows/test-check-review-gate.yml
@@ -1,0 +1,52 @@
+name: Test Check Review Gate Action
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to run the gate against"
+        required: true
+        type: string
+      event_name:
+        description: "Event name to simulate"
+        required: true
+        type: choice
+        options:
+          - labeled
+          - opened
+          - ready_for_review
+          - reopened
+          - synchronize
+        default: opened
+
+permissions: {}
+
+jobs:
+  gate:
+    name: Run gate
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run check-review-gate
+        id: gate
+        uses: ./check-review-gate
+        with:
+          event_name: ${{ inputs.event_name }}
+          pr_number: ${{ inputs.pr_number }}
+          repository: ${{ github.repository }}
+          token: ${{ github.token }}
+
+      - name: Print gate result
+        env:
+          SHOULD_REVIEW: ${{ steps.gate.outputs.should_review }}
+          REVIEW_VARIANT: ${{ steps.gate.outputs.review_variant }}
+          SKIP_REASON: ${{ steps.gate.outputs.skip_reason }}
+        run: |
+          echo "should_review=$SHOULD_REVIEW"
+          echo "review_variant=$REVIEW_VARIANT"
+          echo "skip_reason=$SKIP_REASON"

--- a/check-review-gate/README.md
+++ b/check-review-gate/README.md
@@ -1,14 +1,14 @@
 # Check Review Gate
 
-Determines whether a Claude Code AI review should run on a pull request, routing through a label-triggered path or an automatic safety net.
+Determines whether an AI-powered code review should run on a pull request. The `ai-review-vnext` or `ai-review` labels are the primary opt-in signal that an engineer desires an AI code review. The at-least-one AI-powered code review rule states that if a PR is being opened, reopening, or publishing from a draft state then we must validate. The way we validate is by using a sticky comment with a hidden HTML marker.
 
 ## How It Works
 
 The gate evaluates two paths in order:
 
-**Label path** (checked first): If the PR carries `ai-review-vnext` or `ai-review`, the review proceeds immediately. Draft status is ignored — a reviewer explicitly asked for a review.
+**Label path**: If the PR carries `ai-review-vnext` or `ai-review`, the review proceeds immediately without validating the at-least-one rule.
 
-**Safety net** (when no label matched): Fires on `opened`, `ready_for_review`, and `reopened` events for non-draft PRs that do not already have a review comment. Prevents duplicate reviews on push-triggered re-runs.
+**At-least-one rules**: Validates that a non-draft PR has at least one AI-powered code review when the event trigger is `opened`, `ready_for_review`, and `reopened`.
 
 ## Inputs
 
@@ -37,13 +37,11 @@ The gate evaluates two paths in order:
       ```
       event_name: ${{ github.event_name }}
       ```
-- Optional
   - `marker_id`
     - Description: HTML comment marker ID used to detect an existing review comment (idempotency guard). Must match the `marker_id` passed to `update-pr-comment`.
-    - Default: `bitwarden-code-review`
     - Example:
       ```
-      marker_id: my-review-marker
+      marker_id: bitwarden-code-review
       ```
 
 ## Outputs
@@ -68,10 +66,11 @@ The gate evaluates two paths in order:
   id: gate
   uses: bitwarden/gh-actions/check-review-gate@main
   with:
-    token: ${{ github.token }}
+    event_name: ${{ github.event_name }}
+    marker_id: bitwarden-code-review
     pr_number: ${{ github.event.pull_request.number }}
     repository: ${{ github.repository }}
-    event_name: ${{ github.event_name }}
+    token: ${{ github.token }}
 
 - name: Run review
   if: steps.gate.outputs.should_review == 'true'

--- a/check-review-gate/README.md
+++ b/check-review-gate/README.md
@@ -1,0 +1,79 @@
+# Check Review Gate
+
+Determines whether a Claude Code AI review should run on a pull request, routing through a label-triggered path or an automatic safety net.
+
+## How It Works
+
+The gate evaluates two paths in order:
+
+**Label path** (checked first): If the PR carries `ai-review-vnext` or `ai-review`, the review proceeds immediately. Draft status is ignored — a reviewer explicitly asked for a review.
+
+**Safety net** (when no label matched): Fires on `opened`, `ready_for_review`, and `reopened` events for non-draft PRs that do not already have a review comment. Prevents duplicate reviews on push-triggered re-runs.
+
+## Inputs
+
+- Required
+  - `token`
+    - Description: GitHub token for API access.
+    - Example:
+      ```
+      token: ${{ github.token }}
+      ```
+  - `pr_number`
+    - Description: Pull request number.
+    - Example:
+      ```
+      pr_number: ${{ github.event.pull_request.number }}
+      ```
+  - `repository`
+    - Description: Repository in `owner/repo` format.
+    - Example:
+      ```
+      repository: ${{ github.repository }}
+      ```
+  - `event_name`
+    - Description: The triggering event name from the calling workflow.
+    - Example:
+      ```
+      event_name: ${{ github.event_name }}
+      ```
+- Optional
+  - `marker_id`
+    - Description: HTML comment marker ID used to detect an existing review comment (idempotency guard). Must match the `marker_id` passed to `update-pr-comment`.
+    - Default: `bitwarden-code-review`
+    - Example:
+      ```
+      marker_id: my-review-marker
+      ```
+
+## Outputs
+
+| Output           | Description                                                            |
+| ---------------- | ---------------------------------------------------------------------- |
+| `should_review`  | `true` if a review should execute, `false` otherwise                   |
+| `review_variant` | `current` or `vnext` when `should_review=true`; empty string otherwise |
+| `skip_reason`    | Human-readable explanation when `should_review=false`                  |
+
+## Required Permissions
+
+| Permission      | Access | Reason                          |
+| --------------- | ------ | ------------------------------- |
+| `pull-requests` | `read` | Fetch PR labels and comments    |
+| `contents`      | `read` | Check out the action definition |
+
+## Example
+
+```yaml
+- name: Check review gate
+  id: gate
+  uses: bitwarden/gh-actions/check-review-gate@main
+  with:
+    token: ${{ github.token }}
+    pr_number: ${{ github.event.pull_request.number }}
+    repository: ${{ github.repository }}
+    event_name: ${{ github.event_name }}
+
+- name: Run review
+  if: steps.gate.outputs.should_review == 'true'
+  run: echo "Running ${{ steps.gate.outputs.review_variant }} review"
+```

--- a/check-review-gate/action.yml
+++ b/check-review-gate/action.yml
@@ -1,0 +1,122 @@
+name: "Check Review Gate"
+description: "Determines whether a Claude Code review should run on a pull request"
+author: "Bitwarden"
+branding:
+  icon: shield
+  color: blue
+
+inputs:
+  event_name:
+    description: "Triggering event name (github.event_name from the calling workflow)"
+    required: true
+  marker_id:
+    description: "Sticky comment marker ID to check for an existing review"
+    required: false
+    default: "bitwarden-code-review"
+  pr_number:
+    description: "Pull request number"
+    required: true
+  repository:
+    description: "Repository in owner/repo format"
+    required: true
+  token:
+    description: "GitHub token for API access"
+    required: true
+
+outputs:
+  should_review:
+    description: "'true' if a review should be executed, 'false' otherwise"
+    value: ${{ steps.gate.outputs.should_review }}
+  review_variant:
+    description: "Review variant to use: 'current' or 'vnext' (empty string when should_review=false)"
+    value: ${{ steps.gate.outputs.review_variant }}
+  skip_reason:
+    description: "Human-readable reason when should_review=false"
+    value: ${{ steps.gate.outputs.skip_reason }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Evaluate review gate
+      id: gate
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        PR_NUMBER: ${{ inputs.pr_number }}
+        REPOSITORY: ${{ inputs.repository }}
+        EVENT_NAME: ${{ inputs.event_name }}
+        MARKER_ID: ${{ inputs.marker_id }}
+      run: |
+        set -euo pipefail
+
+        if [[ -z "$PR_NUMBER" ]] || [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+          echo "::error::Invalid pr_number: must be a positive integer"
+          exit 1
+        fi
+
+        if [[ -z "$REPOSITORY" ]] || [[ ! "$REPOSITORY" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+          echo "::error::Invalid repository format: must be 'owner/repo'"
+          exit 1
+        fi
+
+        if [[ -z "$MARKER_ID" ]] || [[ ! "$MARKER_ID" =~ ^[A-Za-z0-9_-]+$ ]]; then
+          echo "::error::Invalid marker_id: must be alphanumeric with hyphens/underscores"
+          exit 1
+        fi
+
+        PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json isDraft,labels)
+        IS_DRAFT=$(echo "$PR_JSON" | jq -r '.isDraft')
+        LABELS=$(echo "$PR_JSON" | jq -r '.labels[].name')
+        SAFETY_NET_EVENTS="opened ready_for_review reopened"
+
+        if printf '%s\n' "$LABELS" | grep -Fxq "ai-review-vnext"; then
+          echo "should_review=true" >> "$GITHUB_OUTPUT"
+          echo "review_variant=vnext" >> "$GITHUB_OUTPUT"
+          echo "skip_reason=" >> "$GITHUB_OUTPUT"
+          echo "✅ Gate: 'ai-review-vnext' label found — review will proceed (variant: vnext)"
+          exit 0
+        fi
+
+        if printf '%s\n' "$LABELS" | grep -Fxq "ai-review"; then
+          echo "should_review=true" >> "$GITHUB_OUTPUT"
+          echo "review_variant=current" >> "$GITHUB_OUTPUT"
+          echo "skip_reason=" >> "$GITHUB_OUTPUT"
+          echo "✅ Gate: 'ai-review' label found — review will proceed (variant: current)"
+          exit 0
+        fi
+
+        if [ "$IS_DRAFT" = "true" ]; then
+          echo "should_review=false" >> "$GITHUB_OUTPUT"
+          echo "review_variant=" >> "$GITHUB_OUTPUT"
+          echo "skip_reason=PR is a draft (safety net does not run on drafts)" >> "$GITHUB_OUTPUT"
+          echo "⚠️ Gate: Safety net: PR is a draft — skipping review"
+          exit 0
+        fi
+
+        if ! printf '%s\n' $SAFETY_NET_EVENTS | grep -Fxq "$EVENT_NAME"; then
+          echo "should_review=false" >> "$GITHUB_OUTPUT"
+          echo "review_variant=" >> "$GITHUB_OUTPUT"
+          echo "skip_reason=No review label and event '${EVENT_NAME}' is not a safety-net trigger" >> "$GITHUB_OUTPUT"
+          echo "⚠️ Gate: No review label and event '${EVENT_NAME}' is not in [${SAFETY_NET_EVENTS}] — skipping"
+          exit 0
+        fi
+
+        # Idempotency guard — skip if a review comment with this marker already exists
+        # Pattern from get-pull-request-threads/action.yml
+        COMMENTS_RESPONSE=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json comments)
+        MARKER="<!-- ${MARKER_ID} -->"
+        HAS_REVIEW=$(echo "$COMMENTS_RESPONSE" | jq -r --arg marker "$MARKER" --arg bot "github-actions[bot]" \
+          '[.comments[] | select(.author.login == $bot) | select(.body | contains($marker))] | length')
+
+        if [ "$HAS_REVIEW" -gt "0" ]; then
+          echo "should_review=false" >> "$GITHUB_OUTPUT"
+          echo "review_variant=" >> "$GITHUB_OUTPUT"
+          echo "skip_reason=Review already exists (sticky comment found with marker '${MARKER_ID}')" >> "$GITHUB_OUTPUT"
+          echo "⚠️ Gate: Existing review comment found — skipping (idempotency)"
+          exit 0
+        fi
+
+        echo "should_review=true" >> "$GITHUB_OUTPUT"
+        echo "review_variant=current" >> "$GITHUB_OUTPUT"
+        echo "skip_reason=" >> "$GITHUB_OUTPUT"
+        echo "✅ Gate: Safety net triggered (event: ${EVENT_NAME}) — review will proceed (variant: current)"

--- a/check-review-gate/action.yml
+++ b/check-review-gate/action.yml
@@ -1,5 +1,5 @@
 name: "Check Review Gate"
-description: "Determines whether a Claude Code review should run on a pull request"
+description: "Determines whether an AI-powered code review should run on a pull request"
 author: "Bitwarden"
 branding:
   icon: shield
@@ -11,8 +11,7 @@ inputs:
     required: true
   marker_id:
     description: "Sticky comment marker ID to check for an existing review"
-    required: false
-    default: "bitwarden-code-review"
+    required: true
   pr_number:
     description: "Pull request number"
     required: true
@@ -65,9 +64,7 @@ runs:
         fi
 
         PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json isDraft,labels)
-        IS_DRAFT=$(echo "$PR_JSON" | jq -r '.isDraft')
         LABELS=$(echo "$PR_JSON" | jq -r '.labels[].name')
-        SAFETY_NET_EVENTS="opened ready_for_review reopened"
 
         if printf '%s\n' "$LABELS" | grep -Fxq "ai-review-vnext"; then
           echo "should_review=true" >> "$GITHUB_OUTPUT"
@@ -85,6 +82,9 @@ runs:
           exit 0
         fi
 
+        # The following starts the at-least-one AI code review rules.
+        # We require the PR to be non-draft for the safety net to trigger to ensure reviews are not run on work-in-progress PRs.
+        IS_DRAFT=$(echo "$PR_JSON" | jq -r '.isDraft')
         if [ "$IS_DRAFT" = "true" ]; then
           echo "should_review=false" >> "$GITHUB_OUTPUT"
           echo "review_variant=" >> "$GITHUB_OUTPUT"
@@ -93,6 +93,8 @@ runs:
           exit 0
         fi
 
+        # The at-least-one AI code review rule only triggers on specific events to avoid unwanted reviews.
+        SAFETY_NET_EVENTS="opened ready_for_review reopened"
         if ! printf '%s\n' $SAFETY_NET_EVENTS | grep -Fxq "$EVENT_NAME"; then
           echo "should_review=false" >> "$GITHUB_OUTPUT"
           echo "review_variant=" >> "$GITHUB_OUTPUT"
@@ -101,7 +103,7 @@ runs:
           exit 0
         fi
 
-        # Idempotency guard — skip if a review comment with this marker already exists
+        # The idempotency guard will skip if an AI-powered code review comment with our marker already exists
         # Pattern from get-pull-request-threads/action.yml
         COMMENTS_RESPONSE=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json comments)
         MARKER="<!-- ${MARKER_ID} -->"

--- a/review-code/README.md
+++ b/review-code/README.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Enables on-demand Claude Code review on Pull Request in GitHub by adding `ai-review` label.
+Runs an automated Claude Code review on pull requests. Reviews fire automatically when a PR is opened, converted from draft, or reopened (safety net), and can be triggered on demand by adding the `ai-review` label.
 
 ## Usage
 
@@ -41,22 +41,23 @@ None
 
 - The calling repository must have access to the `gh-org-bitwarden` Azure Key Vault, which contains the `ANTHROPIC-CODE-REVIEW-API-KEY` secret used to authenticate with the Anthropic API.
 - Only users with **write** permission on the repository can trigger a review. Requests from users without write access are silently skipped.
-- The `ai-review` label must exist in the calling repository.
+- The `ai-review` and `ai-review-vnext` labels must exist in the calling repository.
 
 ### GitHub Permissions
 
 The calling workflow must grant the following GitHub permissions to the `_review-code.yml` action:
 
-| Permission | Access | Reason |
-|---|---|---|
-| `actions` | `read` | Read workflow run status for progress tracking |
-| `contents` | `read` | Check out repo to read code for review |
-| `id-token` | `write` | Authenticate with Azure via OIDC |
-| `pull-requests` | `write` | Post and update comments on pull requests |
+| Permission      | Access  | Reason                                         |
+| --------------- | ------- | ---------------------------------------------- |
+| `actions`       | `read`  | Read workflow run status for progress tracking |
+| `contents`      | `read`  | Check out repo to read code for review         |
+| `id-token`      | `write` | Authenticate with Azure via OIDC               |
+| `pull-requests` | `write` | Post and update comments on pull requests      |
 
 ## Features
 
-- Triggers automatically when the `ai-review` label is added to a pull request
+- **Safety net**: Runs automatically when a PR is opened, converted from draft, or reopened — no label required. Skips if a review comment already exists (idempotency guard).
+- **On-demand label triggers**: Adding `ai-review` runs the current review variant; `ai-review-vnext` runs the next-generation variant. Label triggers bypass draft status and the idempotency guard.
 - Uses a sticky comment — Claude updates a single comment rather than posting new ones
 - Loads Bitwarden's internal plugins: `bitwarden-code-review`, `bitwarden-software-engineer`, `bitwarden-security-engineer`
 - Claude's tool access includes file reading (`Read`, `Grep`, `Glob`), git history (`git diff`, `git log`, `git show`), and PR interaction (`gh pr view/diff/checks`, inline comments)
@@ -68,8 +69,11 @@ The calling workflow must grant the following GitHub permissions to the `_review
 
 ## Troubleshooting
 
-| Symptom | Likely cause |
-|---|---|
-| No review after adding `ai-review` label | Actor lacks write permission, or the calling workflow does not trigger on `labeled` events |
-| Workflow fails at secret retrieval | Azure credentials are missing or the calling workflow did not pass the required secrets |
-| Claude response stops mid-way | 10-minute step timeout was hit; consider breaking the request into smaller tasks |
+| Symptom                                  | Likely cause                                                                                                                              |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| No review when PR is opened              | The calling workflow does not trigger on `opened`, `ready_for_review`, and `reopened` events — copy the latest `review-code.yml` template |
+| No review after adding `ai-review` label | Actor lacks write permission, or the calling workflow does not trigger on `labeled` events                                                |
+| Safety net ran but review was skipped    | A sticky comment with the review marker already exists from a prior run (idempotency guard)                                               |
+| Review skipped on a draft PR             | Expected — the safety net does not run on drafts. Add the `ai-review` label to force a review on a draft.                                 |
+| Workflow fails at secret retrieval       | Azure credentials are missing or the calling workflow did not pass the required secrets                                                   |
+| Claude response stops mid-way            | 10-minute step timeout was hit; consider breaking the request into smaller tasks                                                          |

--- a/review-code/review-code.yml
+++ b/review-code/review-code.yml
@@ -2,7 +2,7 @@ name: Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [labeled, opened, ready_for_review, reopened, synchronize]
 
 permissions: {}
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-36952 - Claude Code Review Workflow Improvements - Q2 2026](https://bitwarden.atlassian.net/browse/PM-36952)

## 📔 Objective

- Refactored the Claude Code Review validation gate into its own composite action. Followed the pattern that we have done for the prior two 'meaty' code review steps.
- Added a new safety net that will ensure that each Bitwarden PR has at least one Claude Code Review by leveraging the hidden marker on the code review's sticky comment. 
- The labeling mechanism is untouched and remains the primary gate to opt-in for a code review regardless of the state of the PR and how many code reviews have been executed. 

## 🚨 Breaking Changes

We do not expect to see any breaking changes with the refactoring of the review gate into its own action and adding a safety-net / fallback mechanism to ensure there's at least one Claude Code Review posted to each PR. 