### PR TITLE
[FIX] Remove GPG signing from _cherry-pick.yml

### DIFF
--- a/.github/workflows/_cherry-pick.yml
+++ b/.github/workflows/_cherry-pick.yml
@@ -69,14 +69,6 @@ jobs:
           keyvault: gh-org-bitwarden
           secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
 
-      - name: Retrieve GPG secrets
-        if: ${{ !inputs.test_mode }}
-        id: retrieve-gpg-secrets
-        uses: bitwarden/gh-actions/get-keyvault-secrets@main
-        with:
-          keyvault: "bitwarden-ci"
-          secrets: "github-gpg-private-key, github-gpg-private-key-passphrase"
-
       - name: Log out from Azure
         if: ${{ !inputs.test_mode }}
         uses: bitwarden/gh-actions/azure-logout@main
@@ -165,19 +157,6 @@ jobs:
         run: |
           git config --local user.name "bitwarden-devops-bot"
           git config --local user.email "106330231+bitwarden-devops-bot@users.noreply.github.com"
-
-      - name: Setup GPG signing
-        if: ${{ !inputs.test_mode }}
-        env:
-          GPG_PRIVATE_KEY: ${{ steps.retrieve-gpg-secrets.outputs.github-gpg-private-key }}
-          GPG_PASSPHRASE: ${{ steps.retrieve-gpg-secrets.outputs.github-gpg-private-key-passphrase }}
-        run: |
-          echo "$GPG_PRIVATE_KEY" | gpg --import --batch
-          GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format=long | grep -o "rsa[0-9]\+/[A-F0-9]\+" | head -n1 | cut -d'/' -f2)
-          git config --local user.signingkey "$GPG_KEY_ID"
-          git config --local commit.gpgsign true
-          export GPG_TTY=$(tty)
-          echo "test" | gpg --clearsign --pinentry-mode=loopback --passphrase "$GPG_PASSPHRASE" > /dev/null 2>&1
 
       - name: Cherry pick
         env:


### PR DESCRIPTION
## 🎟️ Tracking
[Failed Run](https://github.com/bitwarden/clients/actions/runs/26236557210)

## 📔 Objective
This workflow used to commit directly to the destination branch, and it would sign the commits with GPG to satisfy the repository requirements. This workflow no longer has access to the GPG keys and was failing. However, the workflow also no longer commits directly to the destination branch, and opens a PR instead. GPG signing in the workflow is no longer required (the merge commit will be signed by the user who merges the PR), so this PR removes it.