### PR TITLE
PM-36952 - Fix defect and pass the event action

### DIFF
--- a/.github/workflows/_review-code.yml
+++ b/.github/workflows/_review-code.yml
@@ -43,7 +43,7 @@ jobs:
         id: validate
         uses: bitwarden/gh-actions/check-review-gate@main
         with:
-          event_name: ${{ github.event_name }}
+          event_name: ${{ github.event.action }}
           marker_id: bitwarden-code-review
           pr_number: ${{ github.event.pull_request.number }}
           repository: ${{ github.repository }}

--- a/check-review-gate/README.md
+++ b/check-review-gate/README.md
@@ -32,10 +32,10 @@ The gate evaluates two paths in order:
       repository: ${{ github.repository }}
       ```
   - `event_name`
-    - Description: The triggering event name from the calling workflow.
+    - Description: The triggering event action from the calling workflow (e.g. `opened`, `ready_for_review`, `reopened`, `synchronize`).
     - Example:
       ```
-      event_name: ${{ github.event_name }}
+      event_name: ${{ github.event.action }}
       ```
   - `marker_id`
     - Description: HTML comment marker ID used to detect an existing review comment (idempotency guard). Must match the `marker_id` passed to `update-pr-comment`.
@@ -66,7 +66,7 @@ The gate evaluates two paths in order:
   id: gate
   uses: bitwarden/gh-actions/check-review-gate@main
   with:
-    event_name: ${{ github.event_name }}
+    event_name: ${{ github.event.action }}
     marker_id: bitwarden-code-review
     pr_number: ${{ github.event.pull_request.number }}
     repository: ${{ github.repository }}

--- a/check-review-gate/action.yml
+++ b/check-review-gate/action.yml
@@ -7,7 +7,7 @@ branding:
 
 inputs:
   event_name:
-    description: "Triggering event name (github.event_name from the calling workflow)"
+    description: "Triggering event action (github.event.action from the calling workflow, e.g. 'opened', 'ready_for_review', 'reopened', 'synchronize')"
     required: true
   marker_id:
     description: "Sticky comment marker ID to check for an existing review"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-36952 - Claude Code Review Workflow Improvements - Q2 2026](https://bitwarden.atlassian.net/browse/PM-36952)

## 📔 Objective
Follow-up to #772 

We should have been passing the action name to the review gate action; not the event name. 
[references](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request).