### PR TITLE
[BRE-1980] Bumping monitoring timeout to 60 minutes

### DIFF
--- a/trigger-actions/action.yml
+++ b/trigger-actions/action.yml
@@ -33,7 +33,7 @@ inputs:
   monitor-timeout-minutes:
     description: "How long to wait for the downstream deployment to reach a terminal status (success / failure / error), in minutes."
     required: false
-    default: "10"
+    default: "60"
   monitor-poll-interval-seconds:
     description: "How often to poll the downstream deployment for status updates, in seconds."
     required: false


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-1980](https://bitwarden.atlassian.net/browse/BRE-1980)

## 📔 Objective

Bumping monitoring timeout to 60 minutes<br/>

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

[BRE-1980]: https://bitwarden.atlassian.net/browse/BRE-1980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ