### PR TITLE
Minor enhancement to clarify refs that use @main in our workflows

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -47,6 +47,8 @@ Each workflow file must comply with the following linter rules ([source director
 - **step_pinned.py**: Verifies that every workflow step using an external GitHub action in the `uses` key is pinned to a hash with the version in a comment.
 - **underscore_outputs.py**: Enforces that all GitHub outputs with more than one word use an underscore.
 
+> **`bitwarden/gh-actions` refs use `@main` by convention.** `step_pinned.py` and `step_approved.py` are step-level rules targeting third-party external actions; org-internal `bitwarden/` composite actions are pre-approved and SHA-pin exempt, and reusable workflow calls (job-level `uses:`) are not subject to these rules at all. Do not flag `@main` on `bitwarden/gh-actions` paths as a supply-chain finding.
+
 Refer to the [rules directory](https://github.com/bitwarden/workflow-linter/tree/main/src/bitwarden_workflow_linter/rules) for further details or updates to rule logic.
 
 **Trigger**: Automatic on PR when `.github/workflows/**` files change


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

While working on #814 + #604 and executing [performing-multi-agent-code-review](https://github.com/bitwarden/ai-plugins/tree/main/plugins/bitwarden-code-review/skills/performing-multi-agent-code-review), I noticed the Claude agents were debating about whether or not to raise pinning to `@main` was a valid finding.  I found that by carefully analyzing the prompting and responses of the subagents (thank you Claude for `control + o` and `/debug`).  

I then worked with Claude after analyzing the [workflow-linter](https://github.com/bitwarden/workflow-linter) and that's what brought this one bullet enhancement. A more clear rule in the `CLAUDE.md` in the spot that I chose feels best because now Claude doesn't need to consider what some workflows are pinned to `@main`.