### PR TITLE
Remove unnecessary checkout work

### DIFF
--- a/.github/workflows/_check-permission.yml
+++ b/.github/workflows/_check-permission.yml
@@ -36,11 +36,6 @@ jobs:
       user_permission: ${{ steps.check.outputs.user_permission }}
       should_proceed: ${{ steps.check.outputs.should_proceed }}
     steps:
-      - name: Check out repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
       - name: Check user permission
         id: check
         uses: bitwarden/gh-actions/check-permission@main


### PR DESCRIPTION
## 🎟️ Tracking

[VULN-325](https://bitwarden.atlassian.net/browse/VULN-325)

## 📔 Objective

While working to complete VULN-325, @mandreko-bitwarden pointed out that the checkout work was unnecessary work. I researched it (with double-checking from Claude) and raised this PR to remove that action.  Matt's comment is [here](https://github.com/bitwarden/gh-actions/pull/604#discussion_r3405296978)

## Testing 🧪

The test workflow ran successfully 😁
https://github.com/bitwarden/gh-actions/actions/runs/27549928739


[VULN-325]: https://bitwarden.atlassian.net/browse/VULN-325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ