### PR TITLE
Update token handling in artifact-manifest action

### DIFF
--- a/.github/workflows/test-artifact-manifest.yml
+++ b/.github/workflows/test-artifact-manifest.yml
@@ -14,8 +14,6 @@ jobs:
   build-text-file:
     name: Build Text File
     runs-on: ubuntu-24.04
-    permissions:
-      actions: write
     steps:
       - name: Create artifact
         run: echo "hello from build" > output.txt
@@ -29,8 +27,6 @@ jobs:
   build-json-file:
     name: Build JSON File
     runs-on: ubuntu-24.04
-    permissions:
-      actions: write
     steps:
       - name: Create artifact
         run: echo '{"version":"1.0.0"}' > data.json

--- a/.github/workflows/test-artifact-manifest.yml
+++ b/.github/workflows/test-artifact-manifest.yml
@@ -1,0 +1,116 @@
+---
+name: Test Artifact Manifest
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "artifact-manifest/**"
+      - ".github/workflows/test-artifact-manifest.yml"
+
+permissions: {}
+
+jobs:
+  build-text-file:
+    name: Build Text File
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+    steps:
+      - name: Create artifact
+        run: echo "hello from build" > output.txt
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: text-file
+          path: output.txt
+
+  build-json-file:
+    name: Build JSON File
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+    steps:
+      - name: Create artifact
+        run: echo '{"version":"1.0.0"}' > data.json
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: json-file
+          path: data.json
+
+  upload-manifest:
+    name: Upload Manifest
+    runs-on: ubuntu-24.04
+    needs:
+      - build-text-file
+      - build-json-file
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Create and upload manifest
+        id: manifest
+        uses: ./artifact-manifest
+        with:
+          mode: upload
+          gha_artifacts: |
+            text-file
+            json-file
+          additional_artifacts: |
+            {
+              "server": {
+                "type": "container_image",
+                "registry": "bitwardenprod.azurecr.io",
+                "image": "server",
+                "tag": "main",
+                "digest": "sha256:87dfc8005eec18f6b397e350a7f8b7ec4d1fab55f3b6534bf04fb06a04c53f27"
+              }
+            }
+
+      - name: Print manifest output
+        env:
+          _MANIFEST: ${{ steps.manifest.outputs.manifest }}
+        run: echo "$_MANIFEST" | jq .
+
+  download-manifest:
+    name: Download Manifest
+    runs-on: ubuntu-24.04
+    needs: upload-manifest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download manifest
+        id: manifest
+        uses: ./artifact-manifest
+        with:
+          mode: download
+          run_id: ${{ github.run_id }}
+
+      - name: Print manifest
+        env:
+          _MANIFEST: ${{ steps.manifest.outputs.manifest }}
+        run: echo "$_MANIFEST" | jq .
+
+      - name: Print specific fields
+        env:
+          _SHA: ${{ fromJSON(steps.manifest.outputs.manifest).sha }}
+          _REF: ${{ fromJSON(steps.manifest.outputs.manifest).ref }}
+          _SERVER_DIGEST: ${{ fromJSON(steps.manifest.outputs.manifest).artifacts.server.digest }}
+        run: |
+          echo "SHA: $_SHA"
+          echo "Ref: $_REF"
+          echo "Server digest: $_SERVER_DIGEST"

--- a/.github/workflows/test-artifact-manifest.yml
+++ b/.github/workflows/test-artifact-manifest.yml
@@ -55,6 +55,8 @@ jobs:
       - name: Create and upload manifest
         id: manifest
         uses: ./artifact-manifest
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           mode: upload
           gha_artifacts: |
@@ -92,6 +94,8 @@ jobs:
       - name: Download manifest
         id: manifest
         uses: ./artifact-manifest
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           mode: download
           run_id: ${{ github.run_id }}

--- a/.github/workflows/test-artifact-manifest.yml
+++ b/.github/workflows/test-artifact-manifest.yml
@@ -21,7 +21,7 @@ jobs:
         run: echo "hello from build" > output.txt
 
       - name: Upload artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: text-file
           path: output.txt
@@ -36,7 +36,7 @@ jobs:
         run: echo '{"version":"1.0.0"}' > data.json
 
       - name: Upload artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: json-file
           path: data.json

--- a/artifact-manifest/README.md
+++ b/artifact-manifest/README.md
@@ -1,0 +1,170 @@
+# Artifact Manifest Action
+
+## Description
+The `artifact-manifest` action builds and uploads, or downloads and parses, a CI artifact manifest — a JSON inventory of all artifacts produced by a workflow run. It supports two modes: `upload` to collect and publish the manifest at the end of a build, and `download` to retrieve and parse it in a downstream workflow.
+
+Use this action to create an auditable record of exactly what a run produced, pass artifact metadata between workflows, or support supply chain visibility for both GitHub Actions native artifacts and external artifacts like container images or release blobs.
+
+## Key Features
+- **Dual upload/download modes**: One action handles both publishing and consuming the manifest
+- **Flexible artifact selection**: Include all GHA artifacts with `*`, or specify by name
+- **External artifact support**: Merge non-GHA artifacts (container images, blobs, release assets) via `additional_artifacts`
+- **Paginated API handling**: Correctly handles runs with more than 100 artifacts
+- **No external dependencies**: Pure Python standard library — no pip installs required
+
+## How to Use It
+
+### Upload Mode
+Add this step at the end of a build job, after all artifacts have been uploaded:
+
+```yaml
+- name: Upload artifact manifest
+  uses: bitwarden/gh-actions/artifact-manifest@main
+  with:
+    mode: upload
+    gha_artifacts: |
+      my-build-artifact
+      my-test-results
+    additional_artifacts: |
+      {
+        "my-container-image": {
+          "type": "container_image",
+          "image": "ghcr.io/myorg/myrepo",
+          "tag": "1.2.3",
+          "sha": "sha256:abc123..."
+        }
+      }
+```
+
+Inputs:
+- `mode`: Set to `upload`
+- `gha_artifacts`: Newline-separated list of GHA artifact names that have been uploaded to the current run to include. Use `*` to include all artifacts from the run (the manifest itself is always excluded). Omit to include none.
+- `additional_artifacts`: JSON object of non-GHA artifact entries to merge into the manifest. Keys are logical artifact names; values are type-specific objects.
+- `github_token`: GitHub token used to query the run's artifact list. Defaults to `${{ github.token }}`.
+
+### Download Mode
+Reference the manifest in a downstream workflow using the run ID from the upstream run:
+
+```yaml
+- name: Download artifact manifest
+  id: manifest
+  uses: bitwarden/gh-actions/artifact-manifest@main
+  with:
+    mode: download
+    run_id: ${{ github.event.workflow_run.id }}
+
+- name: Print raw manifest
+  run: echo '${{ steps.manifest.outputs.manifest }}'
+
+- name: Print container image SHA manifest
+  run: echo '${{ fromJSON(steps.manifest.outputs.manifest).artifacts.my-docker-image.sha }}'
+```
+
+Inputs:
+- `mode`: Set to `download`
+- `run_id`: The workflow run ID to download the manifest from. Required.
+- `repo`: The `owner/repo` to download from. Defaults to the current repository.
+- `github_token`: GitHub token with artifact read access. Defaults to `${{ github.token }}`.
+
+Outputs:
+- `manifest`: The full manifest as a JSON string, accessible via `${{ steps.<step-id>.outputs.manifest }}`. Also available in upload mode.
+
+- Individual values can be accessed using `fromJSON()`:
+
+  ```yaml
+  echo ${{ fromJSON(steps.<step-id>.outputs.manifest).artifacts.my-container-image.sha }}
+  ```
+
+## Manifest Schema
+
+The action produces `artifact_manifest.json`. The schema is versioned via `manifest_version` and is intended to be a stable, machine-readable record of a workflow run's outputs.
+
+### Top-level fields
+
+| Field | Type | Description |
+|---|---|---|
+| `manifest_version` | string | Schema version. Currently `"1"`. |
+| `run_id` | string | GitHub Actions workflow run ID. |
+| `repository` | string | Repository in `owner/repo` format. |
+| `sha` | string | Full commit SHA the workflow ran against. |
+| `ref` | string | Branch or tag name (e.g. `main`, `rc`). |
+| `workflow_name` | string | Name of the workflow that produced the manifest. |
+| `actor` | string | GitHub user or app that triggered the run. |
+| `manifest_build_time` | string | ISO 8601 UTC timestamp of when the manifest was built. |
+| `artifacts` | object | Map of artifact name → artifact entry. See below. |
+
+### Artifact entries
+
+Each key in `artifacts` is the logical artifact name. The `type` field identifies the artifact kind; all other fields are type-specific.
+
+#### `gha_artifact` — GitHub Actions native artifact
+
+Populated automatically from the run when using `gha_artifacts`.
+
+| Field | Type | Description |
+|---|---|---|
+| `type` | string | `"gha_artifact"` |
+| `run_id` | string | Run ID the artifact was uploaded in. |
+| `name` | string | Artifact name as uploaded via `actions/upload-artifact`. |
+| `checksum` | string | Digest provided by GitHub, if available. Empty string otherwise. |
+
+#### Custom types — non-GHA artifacts
+
+Provided via `additional_artifacts`. The `type` field is required; all other fields are defined by the caller and passed through as-is. See **_How to use it_** section for an example of using `additional_artifacts`.
+
+### Example
+
+```json
+{
+  "manifest_version": "1",
+  "run_id": "12345678",
+  "repository": "myorg/myrepo",
+  "sha": "abc123def456",
+  "ref": "main",
+  "workflow_name": "Build",
+  "actor": "github-actions[bot]",
+  "manifest_build_time": "2025-01-15T10:30:00Z",
+  "artifacts": {
+    "my-build-artifact": {
+      "type": "gha_artifact",
+      "run_id": "12345678",
+      "name": "my-build-artifact",
+      "checksum": "sha256:abc123..."
+    },
+    "my-container-image": {
+      "type": "container_image",
+      "image": "ghcr.io/myorg/myrepo",
+      "tag": "1.2.3",
+      "sha": "sha256:123abc..."
+    }
+  }
+}
+```
+
+## Requirements
+- For `upload` mode, the GitHub token must have `actions: read` permission to query the run artifacts from the GitHub API
+- The `gh` CLI must be available on the runner for download mode (present by default on GitHub-hosted runners)
+- In `download` mode, for cross-repo downloads, the token must have `actions: read` on the target repository — the default `github.token` is scoped to the current repository only and will not work
+
+## Troubleshooting
+
+### "Requested GHA artifacts not found in this run" error
+- Verify the artifact name in `gha_artifacts` exactly matches the `name` field used in `actions/upload-artifact`
+- Names are case-sensitive
+- Ensure the upload step ran before the manifest step in the same workflow run
+- Use `*` to include all artifacts and inspect the manifest to confirm available names
+
+### "Failed to parse additional_artifacts" error
+- The `additional_artifacts` input must be valid JSON
+- Validate your JSON using a linter before passing it to the action
+- Multiline YAML block scalars (`|`) can introduce unexpected indentation — use a single-line string or a `fromJSON` expression if constructing the value dynamically
+
+### "Run ID is required for `download` mode" error
+- The `run_id` input is required when `mode` is `download`
+- In `workflow_run`-triggered workflows, use `${{ github.event.workflow_run.id }}`
+- In manually triggered or other contexts, pass the run ID explicitly
+
+### Artifact not found during download
+- Confirm the upstream run completed successfully and the manifest was uploaded
+- Verify `repo` points to the correct repository if downloading cross-repo
+- The artifact is uploaded under the name `artifact-manifest` — it must not have been deleted or expired

--- a/artifact-manifest/README.md
+++ b/artifact-manifest/README.md
@@ -44,7 +44,7 @@ Inputs:
 - `additional_artifacts`: JSON object of non-GHA artifact entries to merge into the manifest. Keys are logical artifact names; values are type-specific objects.
 
 Environment:
-- `GITHUB_TOKEN`: GitHub token used to query the run's artifact list. **Required.** Pass the default token via `env: GITHUB_TOKEN: ${{ github.token }}`, or use a GitHub App token for cross-repo access or elevated permissions.
+- `GITHUB_TOKEN`: GitHub token used to query the run's artifact list. **Required.** Pass via `env: GITHUB_TOKEN: ${{ github.token }}`.
 
 ### Download Mode
 Reference the manifest in a downstream workflow using the run ID from the upstream run:
@@ -76,7 +76,7 @@ Inputs:
 - `repo`: The `owner/repo` to download from. Defaults to the current repository.
 
 Environment:
-- `GITHUB_TOKEN`: GitHub token with artifact read access. **Required.** Pass the default token via `env: GITHUB_TOKEN: ${{ github.token }}`, or use a GitHub App token for cross-repo downloads with `actions: read` permission on the target repository.
+- `GITHUB_TOKEN`: GitHub token with artifact read access. **Required.** Pass via `env: GITHUB_TOKEN: ${{ github.token }}`. For cross-repo downloads, use a GitHub App token with `actions: read` permission on the target repository.
 
 Outputs:
 - `manifest`: The full manifest as a JSON string, accessible via `${{ steps.<step-id>.outputs.manifest }}`. Also available in upload mode.
@@ -91,7 +91,7 @@ Outputs:
 
 ### Using Custom Tokens
 
-For cross-repo access or elevated permissions, use a GitHub App token passed via the `env` parameter:
+For cross-repo artifact downloads, use a GitHub App token passed via the `env` parameter:
 
 ```yaml
 - name: Generate app token
@@ -275,7 +275,7 @@ Provided via `additional_artifacts`. The `type` field is required; all other fie
 - Python 3.6 or later must be available on the runner (present by default on GitHub-hosted runners)
 - For `upload` mode, the GitHub token must have `actions: read` permission to query the run artifacts from the GitHub API
 - The `gh` CLI must be available on the runner for download mode (present by default on GitHub-hosted runners)
-- In `download` mode, for cross-repo downloads, pass a custom token with `actions: read` on the target repository via `env: GITHUB_TOKEN` — the default `GITHUB_TOKEN` is scoped to the current repository only. Take care to ensure the token is properly masked in Action run logs.
+- In `download` mode, for cross-repo downloads, use a GitHub App token with `actions: read` on the target repository — the default `GITHUB_TOKEN` is scoped to the current repository only
 
 ## Troubleshooting
 
@@ -301,4 +301,4 @@ Provided via `additional_artifacts`. The `type` field is required; all other fie
 - The artifact is uploaded under the name `artifact-manifest` — it must not have been deleted or expired
 
 ### "GITHUB_TOKEN environment variable is required"
-- Confirm that the `GITHUB_TOKEN` environment variable is set in an `env:` block when using `download` mode
+- Confirm that the `GITHUB_TOKEN` environment variable is set in an `env:` block

--- a/artifact-manifest/README.md
+++ b/artifact-manifest/README.md
@@ -81,6 +81,89 @@ Outputs:
   run: echo "$IMAGE_SHA"
   ```
 
+### CI/CD Workflow Handoff Example
+
+A common pattern is to have a CI workflow build and upload the manifest, then trigger a CD workflow that downloads and uses it:
+
+**CI Workflow (build.yml):**
+```yaml
+name: Build
+on:
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # ... build steps that create artifacts ...
+
+      - name: Upload artifact manifest
+        uses: bitwarden/gh-actions/artifact-manifest@main
+        with:
+          mode: upload
+          gha_artifacts: |
+            build-output
+            test-results
+          additional_artifacts: |
+            {
+              "app-image": {
+                "type": "container_image",
+                "registry": "ghcr.io",
+                "image": "myorg/myapp",
+                "tag": "${{ github.sha }}",
+                "digest": "sha256:..."
+              }
+            }
+```
+
+**CD Workflow (deploy.yml):**
+```yaml
+name: Deploy
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Download artifact manifest
+        id: manifest
+        uses: bitwarden/gh-actions/artifact-manifest@main
+        with:
+          mode: download
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Deploy using manifest data
+        env:
+          IMAGE_DIGEST: ${{ fromJSON(steps.manifest.outputs.manifest).artifacts.app-image.digest }}
+          BUILD_SHA: ${{ fromJSON(steps.manifest.outputs.manifest).sha }}
+        run: |
+          echo "Deploying image: $IMAGE_DIGEST"
+          echo "Built from commit: $BUILD_SHA"
+          # ... deployment logic ...
+```
+
 ## Manifest Schema
 
 The action produces `artifact_manifest.json`. The schema is versioned via `manifest_version` and is intended to be a stable, machine-readable record of a workflow run's outputs.
@@ -148,6 +231,7 @@ Provided via `additional_artifacts`. The `type` field is required; all other fie
 ```
 
 ## Requirements
+- Python 3.6 or later must be available on the runner (present by default on GitHub-hosted runners)
 - For `upload` mode, the GitHub token must have `actions: read` permission to query the run artifacts from the GitHub API
 - The `gh` CLI must be available on the runner for download mode (present by default on GitHub-hosted runners)
 - In `download` mode, for cross-repo downloads, the token must have `actions: read` on the target repository — the default `github.token` is scoped to the current repository only and will not work

--- a/artifact-manifest/README.md
+++ b/artifact-manifest/README.md
@@ -20,6 +20,8 @@ Add this step at the end of a build job, after all artifacts have been uploaded:
 ```yaml
 - name: Upload artifact manifest
   uses: bitwarden/gh-actions/artifact-manifest@main
+  env:
+    GITHUB_TOKEN: ${{ github.token }}
   with:
     mode: upload
     gha_artifacts: |
@@ -42,7 +44,7 @@ Inputs:
 - `additional_artifacts`: JSON object of non-GHA artifact entries to merge into the manifest. Keys are logical artifact names; values are type-specific objects.
 
 Environment:
-- `GITHUB_TOKEN`: GitHub token used to query the run's artifact list. Automatically provided by GitHub Actions. For cross-repo access or elevated permissions, pass a custom token via `env:`.
+- `GITHUB_TOKEN`: GitHub token used to query the run's artifact list. **Required.** Pass the default token via `env: GITHUB_TOKEN: ${{ github.token }}`, or use a GitHub App token for cross-repo access or elevated permissions.
 
 ### Download Mode
 Reference the manifest in a downstream workflow using the run ID from the upstream run:
@@ -51,6 +53,8 @@ Reference the manifest in a downstream workflow using the run ID from the upstre
 - name: Download artifact manifest
   id: manifest
   uses: bitwarden/gh-actions/artifact-manifest@main
+  env:
+    GITHUB_TOKEN: ${{ github.token }}
   with:
     mode: download
     run_id: ${{ github.event.workflow_run.id }}
@@ -72,7 +76,7 @@ Inputs:
 - `repo`: The `owner/repo` to download from. Defaults to the current repository.
 
 Environment:
-- `GITHUB_TOKEN`: GitHub token with artifact read access. Automatically provided by GitHub Actions. For cross-repo downloads, pass a token with `actions: read` permission on the target repository via `env:`.
+- `GITHUB_TOKEN`: GitHub token with artifact read access. **Required.** Pass the default token via `env: GITHUB_TOKEN: ${{ github.token }}`, or use a GitHub App token for cross-repo downloads with `actions: read` permission on the target repository.
 
 Outputs:
 - `manifest`: The full manifest as a JSON string, accessible via `${{ steps.<step-id>.outputs.manifest }}`. Also available in upload mode.
@@ -135,6 +139,8 @@ jobs:
 
       - name: Upload artifact manifest
         uses: bitwarden/gh-actions/artifact-manifest@main
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           mode: upload
           gha_artifacts: |

--- a/artifact-manifest/README.md
+++ b/artifact-manifest/README.md
@@ -44,7 +44,7 @@ Inputs:
 - `additional_artifacts`: JSON object of non-GHA artifact entries to merge into the manifest. Keys are logical artifact names; values are type-specific objects.
 
 Environment:
-- `GITHUB_TOKEN`: GitHub token used to query the run's artifact list. **Required.** Pass via `env: GITHUB_TOKEN: ${{ github.token }}`.
+- `GITHUB_TOKEN`: GitHub token used to query the run's artifact list. **Required when using `gha_artifacts`.** Pass via `env: GITHUB_TOKEN: ${{ github.token }}`. Not required if using only `additional_artifacts`.
 
 ### Download Mode
 Reference the manifest in a downstream workflow using the run ID from the upstream run:
@@ -300,5 +300,7 @@ Provided via `additional_artifacts`. The `type` field is required; all other fie
 - Verify `repo` points to the correct repository if downloading cross-repo
 - The artifact is uploaded under the name `artifact-manifest` — it must not have been deleted or expired
 
-### "GITHUB_TOKEN environment variable is required"
-- Confirm that the `GITHUB_TOKEN` environment variable is set in an `env:` block
+### "GITHUB_TOKEN environment variable is required when using gha_artifacts"
+- This error occurs in upload mode when `gha_artifacts` is specified but `GITHUB_TOKEN` is not set
+- Confirm that the `GITHUB_TOKEN` environment variable is set in an `env:` block: `env: GITHUB_TOKEN: ${{ github.token }}`
+- If using only `additional_artifacts` (no `gha_artifacts`), the token is not required

--- a/artifact-manifest/README.md
+++ b/artifact-manifest/README.md
@@ -8,7 +8,7 @@ Use this action to create an auditable record of exactly what a run produced, pa
 ## Key Features
 - **Dual upload/download modes**: One action handles both publishing and consuming the manifest
 - **Flexible artifact selection**: Include all GHA artifacts with `*`, or specify by name
-- **External artifact support**: Merge non-GHA artifacts (container images, blobs, release assets) via `additional_artifacts`
+- **External artifact support**: Add non-GHA artifacts (container images, blobs, release assets) via `additional_artifacts`
 - **Paginated API handling**: Correctly handles runs with more than 100 artifacts
 - **No external dependencies**: Pure Python standard library — no pip installs required
 
@@ -100,7 +100,7 @@ For cross-repo access or elevated permissions, use a GitHub App token passed via
   with:
     app-id: ${{ vars.APP_ID }}
     private-key: ${{ secrets.APP_PRIVATE_KEY }}
-    repositories: target-repo  # Optional: scope to specific repos
+    repositories: target-repo  # scope to specific repos
 
 - name: Download manifest from another repo
   uses: bitwarden/gh-actions/artifact-manifest@main
@@ -275,7 +275,7 @@ Provided via `additional_artifacts`. The `type` field is required; all other fie
 - Python 3.6 or later must be available on the runner (present by default on GitHub-hosted runners)
 - For `upload` mode, the GitHub token must have `actions: read` permission to query the run artifacts from the GitHub API
 - The `gh` CLI must be available on the runner for download mode (present by default on GitHub-hosted runners)
-- In `download` mode, for cross-repo downloads, pass a custom token with `actions: read` on the target repository via `env: GITHUB_TOKEN` — the default `GITHUB_TOKEN` is scoped to the current repository only
+- In `download` mode, for cross-repo downloads, pass a custom token with `actions: read` on the target repository via `env: GITHUB_TOKEN` — the default `GITHUB_TOKEN` is scoped to the current repository only. Take care to ensure the token is properly masked in Action run logs.
 
 ## Troubleshooting
 
@@ -299,3 +299,6 @@ Provided via `additional_artifacts`. The `type` field is required; all other fie
 - Confirm the upstream run completed successfully and the manifest was uploaded
 - Verify `repo` points to the correct repository if downloading cross-repo
 - The artifact is uploaded under the name `artifact-manifest` — it must not have been deleted or expired
+
+### "GITHUB_TOKEN environment variable is required"
+- Confirm that the `GITHUB_TOKEN` environment variable is set in an `env:` block when using `download` mode

--- a/artifact-manifest/README.md
+++ b/artifact-manifest/README.md
@@ -54,10 +54,14 @@ Reference the manifest in a downstream workflow using the run ID from the upstre
     run_id: ${{ github.event.workflow_run.id }}
 
 - name: Print raw manifest
-  run: echo '${{ steps.manifest.outputs.manifest }}'
+  env:
+    MANIFEST: ${{ steps.manifest.outputs.manifest }}
+  run: echo "$MANIFEST"
 
 - name: Print container image SHA manifest
-  run: echo '${{ fromJSON(steps.manifest.outputs.manifest).artifacts.my-docker-image.sha }}'
+  env:
+    IMAGE_SHA: ${{ fromJSON(steps.manifest.outputs.manifest).artifacts.my-docker-image.sha }}
+  run: echo "$IMAGE_SHA"
 ```
 
 Inputs:
@@ -72,7 +76,9 @@ Outputs:
 - Individual values can be accessed using `fromJSON()`:
 
   ```yaml
-  echo ${{ fromJSON(steps.<step-id>.outputs.manifest).artifacts.my-container-image.sha }}
+  env:
+    IMAGE_SHA: ${{ fromJSON(steps.<step-id>.outputs.manifest).artifacts.my-container-image.sha }}
+  run: echo "$IMAGE_SHA"
   ```
 
 ## Manifest Schema

--- a/artifact-manifest/README.md
+++ b/artifact-manifest/README.md
@@ -40,7 +40,9 @@ Inputs:
 - `mode`: Set to `upload`
 - `gha_artifacts`: Newline-separated list of GHA artifact names that have been uploaded to the current run to include. Use `*` to include all artifacts from the run (the manifest itself is always excluded). Omit to include none.
 - `additional_artifacts`: JSON object of non-GHA artifact entries to merge into the manifest. Keys are logical artifact names; values are type-specific objects.
-- `github_token`: GitHub token used to query the run's artifact list. Defaults to `${{ github.token }}`.
+
+Environment:
+- `GITHUB_TOKEN`: GitHub token used to query the run's artifact list. Automatically provided by GitHub Actions. For cross-repo access or elevated permissions, pass a custom token via `env:`.
 
 ### Download Mode
 Reference the manifest in a downstream workflow using the run ID from the upstream run:
@@ -68,7 +70,9 @@ Inputs:
 - `mode`: Set to `download`
 - `run_id`: The workflow run ID to download the manifest from. Required.
 - `repo`: The `owner/repo` to download from. Defaults to the current repository.
-- `github_token`: GitHub token with artifact read access. Defaults to `${{ github.token }}`.
+
+Environment:
+- `GITHUB_TOKEN`: GitHub token with artifact read access. Automatically provided by GitHub Actions. For cross-repo downloads, pass a token with `actions: read` permission on the target repository via `env:`.
 
 Outputs:
 - `manifest`: The full manifest as a JSON string, accessible via `${{ steps.<step-id>.outputs.manifest }}`. Also available in upload mode.
@@ -80,6 +84,29 @@ Outputs:
     IMAGE_SHA: ${{ fromJSON(steps.<step-id>.outputs.manifest).artifacts.my-container-image.sha }}
   run: echo "$IMAGE_SHA"
   ```
+
+### Using Custom Tokens
+
+For cross-repo access or elevated permissions, use a GitHub App token passed via the `env` parameter:
+
+```yaml
+- name: Generate app token
+  id: app-token
+  uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+  with:
+    app-id: ${{ vars.APP_ID }}
+    private-key: ${{ secrets.APP_PRIVATE_KEY }}
+    repositories: target-repo  # Optional: scope to specific repos
+
+- name: Download manifest from another repo
+  uses: bitwarden/gh-actions/artifact-manifest@main
+  env:
+    GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+  with:
+    mode: download
+    run_id: ${{ github.event.workflow_run.id }}
+    repo: other-org/other-repo
+```
 
 ### CI/CD Workflow Handoff Example
 
@@ -142,14 +169,22 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      actions: read
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Download artifact manifest
         id: manifest
         uses: bitwarden/gh-actions/artifact-manifest@main
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           mode: download
           run_id: ${{ github.event.workflow_run.id }}
@@ -234,7 +269,7 @@ Provided via `additional_artifacts`. The `type` field is required; all other fie
 - Python 3.6 or later must be available on the runner (present by default on GitHub-hosted runners)
 - For `upload` mode, the GitHub token must have `actions: read` permission to query the run artifacts from the GitHub API
 - The `gh` CLI must be available on the runner for download mode (present by default on GitHub-hosted runners)
-- In `download` mode, for cross-repo downloads, the token must have `actions: read` on the target repository — the default `github.token` is scoped to the current repository only and will not work
+- In `download` mode, for cross-repo downloads, pass a custom token with `actions: read` on the target repository via `env: GITHUB_TOKEN` — the default `GITHUB_TOKEN` is scoped to the current repository only
 
 ## Troubleshooting
 

--- a/artifact-manifest/action.yml
+++ b/artifact-manifest/action.yml
@@ -1,0 +1,102 @@
+---
+name: "Artifact Manifest"
+description: "Build and upload, or download and parse a CI artifact manifest."
+
+inputs:
+  mode:
+    description: "'upload' to build and upload the manifest, 'download' to fetch and parse it."
+    required: true
+  github_token:
+    description: "GitHub token"
+    required: false
+    default: ${{ github.token }}
+  gha_artifacts:
+    description: |
+      Newline-separated list of GHA artifact names to include in the manifest.
+      Use '*' to include all artifacts uploaded in this run. Omit to include none.
+    required: false
+    default: ""
+  additional_artifacts:
+    description: |
+      JSON object of non-GHA artifact entries (container images, blobs, release assets)
+      to merge into the manifest. Keys are logical artifact names; values follow the
+      artifact type schema (type, plus type-specific locator fields).
+    required: false
+    default: "{}"
+  repo:
+    description: "Repository (owner/repo) to download the manifest from. Download mode only."
+    required: false
+    default: ${{ github.repository }}
+  run_id:
+    description: "Workflow run ID to download the manifest from. Download mode only."
+    required: false
+    default: ""
+
+outputs:
+  manifest:
+    description: "The manifest as a JSON string."
+    value: ${{ steps.read-manifest-upload.outputs.manifest || steps.read-manifest.outputs.manifest }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build manifest
+      if: inputs.mode == 'upload'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        _RUN_ID: ${{ github.run_id }}
+        _REPOSITORY: ${{ github.repository }}
+        _SHA: ${{ github.sha }}
+        _REF: ${{ github.ref_name }}
+        _WORKFLOW: ${{ github.workflow }}
+        _ACTOR: ${{ github.actor }}
+        _GHA_ARTIFACTS: ${{ inputs.gha_artifacts }}
+        _ADDITIONAL_ARTIFACTS: ${{ inputs.additional_artifacts }}
+      run: python "${{ github.action_path }}/create_manifest.py"
+
+    - name: Upload manifest
+      if: inputs.mode == 'upload'
+      uses: actions/upload-artifact@v4
+      with:
+        name: artifact-manifest
+        path: artifact_manifest.json
+
+    - name: Read manifest
+      id: read-manifest-upload
+      if: inputs.mode == 'upload'
+      shell: bash
+      run: |
+        {
+          echo "manifest<<EOF"
+          cat artifact_manifest.json
+          echo "EOF"
+        } >> $GITHUB_OUTPUT
+
+    - name: Download manifest
+      if: inputs.mode == 'download'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        _REPO: ${{ inputs.repo }}
+        _RUN_ID: ${{ inputs.run_id }}
+      run: |
+        if [[ -z "$_RUN_ID" ]]; then
+          echo '::error::Run ID is required for `download` mode.'
+          exit 1
+        fi
+        gh run download "$_RUN_ID" \
+          --repo "$_REPO" \
+          --name artifact-manifest \
+          --dir ./artifact-manifest-tmp
+
+    - name: Read manifest
+      id: read-manifest
+      if: inputs.mode == 'download'
+      shell: bash
+      run: |
+        {
+          echo "manifest<<EOF"
+          cat ./artifact-manifest-tmp/artifact_manifest.json
+          echo "EOF"
+        } >> $GITHUB_OUTPUT

--- a/artifact-manifest/action.yml
+++ b/artifact-manifest/action.yml
@@ -47,7 +47,9 @@ runs:
 
     - name: Mask GitHub token
       shell: bash
-      run: echo "::add-mask::${{ inputs.github_token }}"
+      env:
+        _TOKEN: "1234567890abcdefghijk"
+      run: echo "::add-mask::$_TOKEN"
 
     - name: Build manifest
       if: inputs.mode == 'upload'

--- a/artifact-manifest/action.yml
+++ b/artifact-manifest/action.yml
@@ -8,28 +8,23 @@ inputs:
     required: true
   github_token:
     description: "GitHub token"
-    required: false
     default: ${{ github.token }}
   gha_artifacts:
     description: |
       Newline-separated list of GHA artifact names to include in the manifest.
       Use '*' to include all artifacts uploaded in this run. Omit to include none.
-    required: false
     default: ""
   additional_artifacts:
     description: |
       JSON object of non-GHA artifact entries (container images, blobs, release assets)
       to merge into the manifest. Keys are logical artifact names; values follow the
       artifact type schema (type, plus type-specific locator fields).
-    required: false
     default: "{}"
   repo:
     description: "Repository (owner/repo) to download the manifest from. Download mode only."
-    required: false
     default: ${{ github.repository }}
   run_id:
     description: "Workflow run ID to download the manifest from. Download mode only."
-    required: false
     default: ""
 
 outputs:
@@ -57,7 +52,7 @@ runs:
 
     - name: Upload manifest
       if: inputs.mode == 'upload'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: artifact-manifest
         path: artifact_manifest.json

--- a/artifact-manifest/action.yml
+++ b/artifact-manifest/action.yml
@@ -6,9 +6,6 @@ inputs:
   mode:
     description: "'upload' to build and upload the manifest, 'download' to fetch and parse it."
     required: true
-  github_token:
-    description: "GitHub token"
-    default: ${{ github.token }}
   gha_artifacts:
     description: |
       Newline-separated list of GHA artifact names to include in the manifest.
@@ -45,17 +42,10 @@ runs:
           exit 1
         fi
 
-    - name: Mask GitHub token
-      shell: bash
-      env:
-        _TOKEN: "1234567890abcdefghijk"
-      run: echo "::add-mask::$_TOKEN"
-
     - name: Build manifest
       if: inputs.mode == 'upload'
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.github_token }}
         _RUN_ID: ${{ github.run_id }}
         _REPOSITORY: ${{ github.repository }}
         _SHA: ${{ github.sha }}
@@ -88,7 +78,6 @@ runs:
       if: inputs.mode == 'download'
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.github_token }}
         _REPO: ${{ inputs.repo }}
         _RUN_ID: ${{ inputs.run_id }}
       run: |

--- a/artifact-manifest/action.yml
+++ b/artifact-manifest/action.yml
@@ -35,6 +35,16 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Validate mode input
+      shell: bash
+      env:
+        _MODE: ${{ inputs.mode }}
+      run: |
+        if [[ "$_MODE" != "upload" && "$_MODE" != "download" ]]; then
+          echo "::error::Invalid mode `$_MODE`. Must be `upload` or `download`."
+          exit 1
+        fi
+
     - name: Build manifest
       if: inputs.mode == 'upload'
       shell: bash

--- a/artifact-manifest/action.yml
+++ b/artifact-manifest/action.yml
@@ -41,9 +41,13 @@ runs:
         _MODE: ${{ inputs.mode }}
       run: |
         if [[ "$_MODE" != "upload" && "$_MODE" != "download" ]]; then
-          echo "::error::Invalid mode `$_MODE`. Must be `upload` or `download`."
+          echo "::error::Invalid mode '$_MODE'. Must be 'upload' or 'download'."
           exit 1
         fi
+
+    - name: Mask GitHub token
+      shell: bash
+      run: echo "::add-mask::${{ inputs.github_token }}"
 
     - name: Build manifest
       if: inputs.mode == 'upload'
@@ -87,7 +91,7 @@ runs:
         _RUN_ID: ${{ inputs.run_id }}
       run: |
         if [[ -z "$_RUN_ID" ]]; then
-          echo '::error::Run ID is required for `download` mode.'
+          echo "::error::Run ID is required for 'download' mode."
           exit 1
         fi
         gh run download "$_RUN_ID" \

--- a/artifact-manifest/create_manifest.py
+++ b/artifact-manifest/create_manifest.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from urllib.request import urlopen, Request
+from urllib.error import HTTPError
+
+
+def get_run_artifacts(token, repository, run_id):
+    url = f"https://api.github.com/repos/{repository}/actions/runs/{run_id}/artifacts?per_page=100"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    
+    artifacts = []
+    # keep looping as long as we have urls to call
+    while url:
+        # build the request object
+        req = Request(url, headers=headers)
+        try:
+            # call the url
+            with urlopen(req) as resp:
+                data = json.loads(resp.read())
+                # grab the "next page" link that GitHub inclides in the response header
+                link_header = resp.headers.get("Link", "")
+        except HTTPError as e:
+            print(f"::error::GitHub API error: {e.code} {e.reason}", file=sys.stderr)
+            sys.exit(1)
+        # combine the list or artifacts from the response with existing list of artifacts
+        artifacts.extend(data["artifacts"])
+        # set var to None. loop will exit if we don't find any "next page" links
+        url = None
+        # loop through all the links in the response header and capture any that are "next page" links
+        for part in link_header.split(","):
+            if 'rel="next"' in part:
+                url = part.split(";")[0].strip().strip("<>")
+    return artifacts
+
+
+def main():
+    # get all the ENV vars
+    token = os.environ["GH_TOKEN"]
+    run_id = os.environ["_RUN_ID"]
+    repository = os.environ["_REPOSITORY"]
+    sha = os.environ["_SHA"]
+    ref = os.environ["_REF"]
+    workflow = os.environ["_WORKFLOW"]
+    actor = os.environ["_ACTOR"]
+    gha_artifacts_input = os.environ.get("_GHA_ARTIFACTS", "").strip()
+    additional_artifacts_raw = os.environ.get("_ADDITIONAL_ARTIFACTS", "{}").strip() or "{}"
+
+    # build the manifest skeleton
+    manifest = {
+        "manifest_version": "1",
+        "run_id": run_id,
+        "repository": repository,
+        "sha": sha,
+        "ref": ref,
+        "workflow_name": workflow,
+        "actor": actor,
+        "manifest_build_time": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "artifacts": {},
+    }
+
+    if gha_artifacts_input:
+        # grab all the artifacts from the given run
+        all_artifacts = get_run_artifacts(token, repository, run_id)
+
+        # if a wildcard is passed in, select all artifacts uploaded to the given run
+        if gha_artifacts_input == "*":
+            selected = [a for a in all_artifacts if a["name"] != "artifact-manifest"]
+        else:
+            # make a set of artifacts that were passed in as input
+            requested = {name.strip() for name in gha_artifacts_input.splitlines() if name.strip()}
+            # filter the full artifact list down to only the ones that were requested
+            selected = [a for a in all_artifacts if a["name"] in requested]
+            # find any requested artifacts that weren't present in the run
+            missing = requested - {a["name"] for a in selected}
+            if missing:
+                print(f"::error::Requested GHA artifacts not found in this run: {', '.join(sorted(missing))}", file=sys.stderr)
+                sys.exit(1)
+
+        # loop through the list of artifacts and add them to the manifest JSON
+        for artifact in selected:
+            manifest["artifacts"][artifact["name"]] = {
+                "type": "gha_artifact",
+                "run_id": run_id,
+                "name": artifact["name"],
+                "checksum": artifact.get("digest", ""),
+            }
+
+    # merge any additional artifacts passed in with the GHA artifacts
+    try:
+        additional = json.loads(additional_artifacts_raw)
+    except json.JSONDecodeError as e:
+        print(f"::error::Failed to parse additional_artifacts: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    manifest["artifacts"].update(additional)
+
+    # write the manifest to a file
+    with open("artifact_manifest.json", "w") as f:
+        json.dump(manifest, f, indent=2)
+        f.write("\n")
+
+    print(json.dumps(manifest, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/artifact-manifest/create_manifest.py
+++ b/artifact-manifest/create_manifest.py
@@ -24,12 +24,12 @@ def get_run_artifacts(token, repository, run_id):
             # call the url
             with urlopen(req) as resp:
                 data = json.loads(resp.read())
-                # grab the "next page" link that GitHub inclides in the response header
+                # grab the "next page" link that GitHub includes in the response header
                 link_header = resp.headers.get("Link", "")
         except HTTPError as e:
             print(f"::error::GitHub API error: {e.code} {e.reason}", file=sys.stderr)
             sys.exit(1)
-        # combine the list or artifacts from the response with existing list of artifacts
+        # combine the list of artifacts from the response with existing list of artifacts
         artifacts.extend(data["artifacts"])
         # set var to None. loop will exit if we don't find any "next page" links
         url = None

--- a/artifact-manifest/create_manifest.py
+++ b/artifact-manifest/create_manifest.py
@@ -16,24 +16,20 @@ def get_run_artifacts(token, repository, run_id):
     }
     
     artifacts = []
-    # keep looping as long as we have urls to call
+    # the GH API uses pagination.
+    # it returns 'rel="next"', followed by a page URL, in the link header if there's another page of results.
+    # keep looping until we've processed all pages.
     while url:
-        # build the request object
         req = Request(url, headers=headers)
         try:
-            # call the url
             with urlopen(req) as resp:
                 data = json.loads(resp.read())
-                # grab the "next page" link that GitHub includes in the response header
                 link_header = resp.headers.get("Link", "")
         except HTTPError as e:
             print(f"::error::GitHub API error: {e.code} {e.reason}", file=sys.stderr)
             sys.exit(1)
-        # combine the list of artifacts from the response with existing list of artifacts
         artifacts.extend(data["artifacts"])
-        # set var to None. loop will exit if we don't find any "next page" links
         url = None
-        # loop through all the links in the response header and capture any that are "next page" links
         for part in link_header.split(","):
             if 'rel="next"' in part:
                 url = part.split(";")[0].strip().strip("<>")
@@ -41,7 +37,6 @@ def get_run_artifacts(token, repository, run_id):
 
 
 def main():
-    # get all the ENV vars
     token = os.environ["GH_TOKEN"]
     run_id = os.environ["_RUN_ID"]
     repository = os.environ["_REPOSITORY"]
@@ -52,7 +47,6 @@ def main():
     gha_artifacts_input = os.environ.get("_GHA_ARTIFACTS", "").strip()
     additional_artifacts_raw = os.environ.get("_ADDITIONAL_ARTIFACTS", "{}").strip() or "{}"
 
-    # build the manifest skeleton
     manifest = {
         "manifest_version": "1",
         "run_id": run_id,
@@ -66,24 +60,18 @@ def main():
     }
 
     if gha_artifacts_input:
-        # grab all the artifacts from the given run
         all_artifacts = get_run_artifacts(token, repository, run_id)
 
-        # if a wildcard is passed in, select all artifacts uploaded to the given run
         if gha_artifacts_input == "*":
             selected = [a for a in all_artifacts if a["name"] != "artifact-manifest"]
         else:
-            # make a set of artifacts that were passed in as input
             requested = {name.strip() for name in gha_artifacts_input.splitlines() if name.strip()}
-            # filter the full artifact list down to only the ones that were requested
             selected = [a for a in all_artifacts if a["name"] in requested]
-            # find any requested artifacts that weren't present in the run
             missing = requested - {a["name"] for a in selected}
             if missing:
                 print(f"::error::Requested GHA artifacts not found in this run: {', '.join(sorted(missing))}", file=sys.stderr)
                 sys.exit(1)
 
-        # loop through the list of artifacts and add them to the manifest JSON
         for artifact in selected:
             manifest["artifacts"][artifact["name"]] = {
                 "type": "gha_artifact",
@@ -101,7 +89,6 @@ def main():
 
     manifest["artifacts"].update(additional)
 
-    # write the manifest to a file
     with open("artifact_manifest.json", "w") as f:
         json.dump(manifest, f, indent=2)
         f.write("\n")

--- a/artifact-manifest/create_manifest.py
+++ b/artifact-manifest/create_manifest.py
@@ -37,10 +37,6 @@ def get_run_artifacts(token, repository, run_id):
 
 
 def main():
-    token = os.environ.get("GITHUB_TOKEN")
-    if not token:
-        print("::error::GITHUB_TOKEN environment variable is required.", file=sys.stderr)
-        sys.exit(1)
     run_id = os.environ["_RUN_ID"]
     repository = os.environ["_REPOSITORY"]
     sha = os.environ["_SHA"]
@@ -63,6 +59,10 @@ def main():
     }
 
     if gha_artifacts_input:
+        token = os.environ.get("GITHUB_TOKEN")
+        if not token:
+            print("::error::GITHUB_TOKEN environment variable is required when using gha_artifacts.", file=sys.stderr)
+            sys.exit(1)
         all_artifacts = get_run_artifacts(token, repository, run_id)
 
         if gha_artifacts_input == "*":

--- a/artifact-manifest/create_manifest.py
+++ b/artifact-manifest/create_manifest.py
@@ -87,6 +87,11 @@ def main():
         print(f"::error::Failed to parse additional_artifacts: {e}", file=sys.stderr)
         sys.exit(1)
 
+    duplicates = manifest["artifacts"].keys() & additional.keys()
+    if duplicates:
+        print(f"::error::Duplicate artifact keys in additional_artifacts: {', '.join(sorted(duplicates))}", file=sys.stderr)
+        sys.exit(1)
+
     manifest["artifacts"].update(additional)
 
     with open("artifact_manifest.json", "w") as f:

--- a/artifact-manifest/create_manifest.py
+++ b/artifact-manifest/create_manifest.py
@@ -37,9 +37,9 @@ def get_run_artifacts(token, repository, run_id):
 
 
 def main():
-    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    token = os.environ.get("GITHUB_TOKEN")
     if not token:
-        print("::error::GITHUB_TOKEN environment variable is required", file=sys.stderr)
+        print("::error::GITHUB_TOKEN environment variable is required.", file=sys.stderr)
         sys.exit(1)
     run_id = os.environ["_RUN_ID"]
     repository = os.environ["_REPOSITORY"]

--- a/artifact-manifest/create_manifest.py
+++ b/artifact-manifest/create_manifest.py
@@ -37,7 +37,10 @@ def get_run_artifacts(token, repository, run_id):
 
 
 def main():
-    token = os.environ["GH_TOKEN"]
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        print("::error::GITHUB_TOKEN environment variable is required", file=sys.stderr)
+        sys.exit(1)
     run_id = os.environ["_RUN_ID"]
     repository = os.environ["_REPOSITORY"]
     sha = os.environ["_SHA"]

--- a/artifact-manifest/create_manifest.py
+++ b/artifact-manifest/create_manifest.py
@@ -87,6 +87,10 @@ def main():
         print(f"::error::Failed to parse additional_artifacts: {e}", file=sys.stderr)
         sys.exit(1)
 
+    if not isinstance(additional, dict):
+        print("::error::additional_artifacts must be a JSON object", file=sys.stderr)
+        sys.exit(1)
+
     duplicates = manifest["artifacts"].keys() & additional.keys()
     if duplicates:
         print(f"::error::Duplicate artifact keys in additional_artifacts: {', '.join(sorted(duplicates))}", file=sys.stderr)


### PR DESCRIPTION
## 🎟️ Tracking
Addendum to [PR-774](https://github.com/bitwarden/gh-actions/pull/774)

## 📔 Objective

Changing the method of passing a GitHub token through the action. Instead of passing it via  `input`, this PR sets an ENV var directly from the `create-github-app-token` step output. This ensures that the token is masked immediately after it's created (inside `create-github-app-token`).
