### PR TITLE
[BRE-2038] Consolidating check run back into 1 job for easy re-running

### DIFF
--- a/.github/workflows/_check-permission.yml
+++ b/.github/workflows/_check-permission.yml
@@ -44,19 +44,3 @@ jobs:
           username: ${{ github.triggering_actor }}
           token: ${{ secrets.GITHUB_TOKEN }}
           failure_mode: ${{ inputs.failure_mode }}
-
-      - name: Report results
-        env:
-          ACTOR: ${{ github.triggering_actor }}
-          REQUIRED: ${{ inputs.require_permission }}
-          ACTUAL: ${{ steps.check.outputs.user_permission }}
-          HAS_PERM: ${{ steps.check.outputs.has_permission }}
-          SHOULD_PROCEED: ${{ steps.check.outputs.should_proceed }}
-        run: |
-          echo "🤖 Permission Check"
-          echo "================================"
-          echo "User: $ACTOR"
-          echo "Required: $REQUIRED"
-          echo "Actual: $ACTUAL"
-          echo "Has permission: $HAS_PERM"
-          echo "Should proceed: $SHOULD_PROCEED"

--- a/.github/workflows/check-run.yml
+++ b/.github/workflows/check-run.yml
@@ -6,26 +6,32 @@ on:
 permissions: {}
 
 jobs:
-  check-permission:
-    name: Check permission
-    uses: bitwarden/gh-actions/.github/workflows/_check-permission.yml@main
-    with:
-      failure_mode: "continue" # Continue so that the BW bot can skip
-      require_permission: "write"
-    permissions:
-      contents: read
-
   check:
     name: Check
     runs-on: ubuntu-24.04
-    needs: check-permission
-    if: ${{ needs.check-permission.outputs.has_permission == 'false' && github.triggering_actor != 'bw-ghapp[bot]' }}
+    permissions:
+      contents: read
 
     steps:
+      # Compute and enforce the permission in the SAME job so that GitHub's
+      # "Re-run failed jobs" re-evaluates against the current github.triggering_actor.
+      # When the permission check lives in a separate job that always succeeds
+      # (failure_mode: continue), "Re-run failed jobs" does not re-run it and the
+      # stale permission of the original triggerer is reused. See bitwarden/gh-actions#604.
+      - name: Check user permission
+        id: check-permission
+        uses: bitwarden/gh-actions/check-permission@main
+        with:
+          require: "write"
+          username: ${{ github.triggering_actor }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          failure_mode: "continue" # Continue so that the BW bot can skip below
+
       - name: Enforce permission check
+        if: ${{ steps.check-permission.outputs.has_permission == 'false' && github.triggering_actor != 'bw-ghapp[bot]' }}
         env:
           GITHUB_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
-          USER_PERMISSIONS: ${{ needs.check-permission.outputs.user_permission }}
+          USER_PERMISSIONS: ${{ steps.check-permission.outputs.user_permission }}
           GITHUB_ACTOR: ${{ github.actor }}
         run: |
           echo "User ${GITHUB_TRIGGERING_ACTOR} does not have the necessary access for this repository."

--- a/.github/workflows/check-run.yml
+++ b/.github/workflows/check-run.yml
@@ -13,11 +13,6 @@ jobs:
       contents: read
 
     steps:
-      # Compute and enforce the permission in the SAME job so that GitHub's
-      # "Re-run failed jobs" re-evaluates against the current github.triggering_actor.
-      # When the permission check lives in a separate job that always succeeds
-      # (failure_mode: continue), "Re-run failed jobs" does not re-run it and the
-      # stale permission of the original triggerer is reused. See bitwarden/gh-actions#604.
       - name: Check user permission
         id: check-permission
         uses: bitwarden/gh-actions/check-permission@main

--- a/check-permission/action.yml
+++ b/check-permission/action.yml
@@ -113,6 +113,7 @@ runs:
         fi
 
     - name: Report results
+      if: always()
       shell: bash
       env:
         USERNAME: ${{ inputs.username }}

--- a/check-permission/action.yml
+++ b/check-permission/action.yml
@@ -111,3 +111,20 @@ runs:
               ;;
           esac
         fi
+
+    - name: Report results
+      shell: bash
+      env:
+        USERNAME: ${{ inputs.username }}
+        REQUIRED: ${{ inputs.require }}
+        ACTUAL: ${{ steps.check-permission.outputs.user_permission }}
+        HAS_PERM: ${{ steps.check-permission.outputs.has_permission }}
+        SHOULD_PROCEED: ${{ steps.check-permission.outputs.should_proceed }}
+      run: |
+        echo "🤖 Permission Check"
+        echo "================================"
+        echo "User: $USERNAME"
+        echo "Required: $REQUIRED"
+        echo "Actual: $ACTUAL"
+        echo "Has permission: $HAS_PERM"
+        echo "Should proceed: $SHOULD_PROCEED"


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-2038](https://bitwarden.atlassian.net/browse/BRE-2038)

## 📔 Objective

Consolidating check run back into 1 job for easy re-running.

The PR below split up the check into 2 jobs:
- https://github.com/bitwarden/gh-actions/pull/604
1. check-permission
2. check


`check-permission` always succeeds after getting the permissions
The `check` job may fail due to a users permissions as expected such as for PR contributions via a fork.

The process is to re-run the job, which usually people will just do "re-run failed jobs", as this used to work.
After this change that no longer works, creating a confusing error message showing the re-run user with the original users permissions.
Doing "Re-run all jobs" correctly works because it re-runs the `check-permission` as well.

This PR just combines those back into 1 job to avoid the re-run confusion.


[BRE-2038]: https://bitwarden.atlassian.net/browse/BRE-2038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ