### PR TITLE
Add Aikido bot to Code-Review skill

### DIFF
--- a/run-code-review/action.yml
+++ b/run-code-review/action.yml
@@ -89,6 +89,7 @@ runs:
       uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1.0.148
       with:
         anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-CODE-REVIEW-API-KEY }}
+        allowed_bots: "aikido-autofix[bot]"
         plugin_marketplaces: "https://github.com/bitwarden/ai-plugins.git"
         plugins: |
           bitwarden-code-review@bitwarden-marketplace


### PR DESCRIPTION
## 📔 Objective

This change allows the Aikido bot to run the code-review skill. 

The code-review skill is currently required for all PRs. But if a PR is created *by* Aikido as part of it's AutoFix functionality, the code-review skill bails with errors, such as shown here: https://github.com/bitwarden/billing-relay/actions/runs/29100602762/job/86398510981?pr=250

```
Trigger result: true
Preparing with mode: agent for event: pull_request
Actor type: Bot
Error: Action failed with error: Workflow initiated by non-human actor: aikido-autofix (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.
```

This corrects that, by allowing Aikido's bot to be a trusted non-human initiator.


