### PR TITLE
[BRE-2140] feat(renovate): add anthropics/claude-code-action override

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,12 +16,6 @@
   ],
   "packageRules": [
     {
-      "matchManagers": ["github-actions"],
-      "matchDepNames": ["anthropics/claude-code-action"],
-      "matchUpdateTypes": ["patch"],
-      "dependencyDashboardApproval": false
-    },
-    {
       "additionalBranchPrefix": "{{parentDir}}-",
       "commitMessagePrefix": "[deps] {{parentDir}}:",
       "groupName": "minor",
@@ -33,6 +27,13 @@
         "pipenv"
       ],
       "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["anthropics/claude-code-action"],
+      "matchUpdateTypes": ["patch"],
+      "groupName": null,
+      "dependencyDashboardApproval": false
     }
   ],
   "regexManagers": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,13 +1,26 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>bitwarden/renovate-config"],
-  "enabledManagers": ["dockerfile", "github-actions", "npm", "nuget", "pipenv", "regex"],
+  "enabledManagers": [
+    "dockerfile",
+    "github-actions",
+    "npm",
+    "nuget",
+    "pipenv",
+    "regex"
+  ],
   "ignorePaths": [
     "release-version-check/tests/fixtures/**",
     "version-bump/tests/fixtures/**",
     "**/node_modules/**"
   ],
   "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["anthropics/claude-code-action"],
+      "matchUpdateTypes": ["patch"],
+      "dependencyDashboardApproval": false
+    },
     {
       "additionalBranchPrefix": "{{parentDir}}-",
       "commitMessagePrefix": "[deps] {{parentDir}}:",


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-2140](https://bitwarden.atlassian.net/browse/BRE-2140)

## 📔 Objective

Enables Renovate to pick-up `anthropics/claude-code-action` action patch [releases](https://github.com/anthropics/claude-code-action/releases).

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, describe the impact and migration path for users of these workflows and shared composite actions.

For this repo, breaking changes can include renamed inputs/outputs, changed defaults, removed steps, or behavior changes that alter workflow results.

For breaking changes:
1. Describe what changed in the workflow or action interface
2. Explain why the change was necessary
3. Provide migration steps and timeline (if any)
4. Link to any paired PRs in consuming repos (if relevant)

Otherwise, you can remove this section. -->


[BRE-2140]: https://bitwarden.atlassian.net/browse/BRE-2140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ