### PR TITLE
[BRE-2104] Add prerelease filtering to get-release-version action

### DIFF
--- a/.github/workflows/test-get-release-version.yml
+++ b/.github/workflows/test-get-release-version.yml
@@ -133,6 +133,16 @@ jobs:
           repository: bitwarden/passwordless-server
           prerelease: "false"
 
+      # Legacy mode: no filtering, newest release regardless of type. Previously covered
+      # implicitly by every case that omits 'prerelease', until the default became "false".
+      - name: Non-monorepo, prerelease='' (most recent regardless of type)
+        id: non_monorepo_legacy
+        continue-on-error: true
+        uses: ./get-release-version
+        with:
+          repository: bitwarden/passwordless-server
+          prerelease: ""
+
       - name: Non-monorepo, prerelease=true, trim=true
         id: non_monorepo_prerelease_trim
         continue-on-error: true
@@ -223,6 +233,8 @@ jobs:
           NON_MONOREPO_PRERELEASE_VERSION: ${{ steps.non_monorepo_prerelease.outputs.version }}
           NON_MONOREPO_STABLE_MIXED_OUTCOME: ${{ steps.non_monorepo_stable_mixed.outcome }}
           NON_MONOREPO_STABLE_MIXED_VERSION: ${{ steps.non_monorepo_stable_mixed.outputs.version }}
+          NON_MONOREPO_LEGACY_OUTCOME: ${{ steps.non_monorepo_legacy.outcome }}
+          NON_MONOREPO_LEGACY_VERSION: ${{ steps.non_monorepo_legacy.outputs.version }}
           NON_MONOREPO_PRERELEASE_TRIM_OUTCOME: ${{ steps.non_monorepo_prerelease_trim.outcome }}
           NON_MONOREPO_PRERELEASE_TRIM_VERSION: ${{ steps.non_monorepo_prerelease_trim.outputs.version }}
           PRERELEASE_NO_MATCH_OUTCOME: ${{ steps.prerelease_no_match.outcome }}
@@ -291,6 +303,7 @@ jobs:
           assert_success "Monorepo desktop, prerelease=false" "$MONOREPO_DESKTOP_STABLE_OUTCOME" "$MONOREPO_DESKTOP_STABLE_VERSION" '^desktop-v[0-9]+\.[0-9]+\.[0-9]+$'
           # Pre-release tags may carry a suffix (e.g. 2025.10.0-beta.1), so this pattern allows one.
           assert_success "Non-monorepo, prerelease=true"      "$NON_MONOREPO_PRERELEASE_OUTCOME" "$NON_MONOREPO_PRERELEASE_VERSION" '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'
+          assert_success "Non-monorepo, prerelease=''"        "$NON_MONOREPO_LEGACY_OUTCOME"     "$NON_MONOREPO_LEGACY_VERSION"     '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'
           assert_success "Non-monorepo, prerelease=true, trim=true" "$NON_MONOREPO_PRERELEASE_TRIM_OUTCOME" "$NON_MONOREPO_PRERELEASE_TRIM_VERSION" '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'
           assert_success "Non-monorepo, prerelease=false on a repo with pre-releases" "$NON_MONOREPO_STABLE_MIXED_OUTCOME" "$NON_MONOREPO_STABLE_MIXED_VERSION" '^[0-9]+\.[0-9]+\.[0-9]+$'
 

--- a/.github/workflows/test-get-release-version.yml
+++ b/.github/workflows/test-get-release-version.yml
@@ -180,6 +180,33 @@ jobs:
           repository: bitwarden/server
           prerelease: "maybe"
 
+      # Near-miss values: substrings of a valid option. These slipped past the old
+      # substring-matching validator and silently changed behaviour.
+      - name: Invalid prerelease value that is a substring of a valid one
+        id: invalid_prerelease_substring
+        continue-on-error: true
+        uses: ./get-release-version
+        with:
+          repository: bitwarden/server
+          prerelease: "tru"
+
+      - name: Invalid trim value that is a substring of a valid one
+        id: invalid_trim_substring
+        continue-on-error: true
+        uses: ./get-release-version
+        with:
+          repository: bitwarden/server
+          trim: "tru"
+
+      - name: Invalid monorepo-project value that is a substring of a valid one
+        id: invalid_monorepo_project_substring
+        continue-on-error: true
+        uses: ./get-release-version
+        with:
+          repository: bitwarden/clients
+          monorepo: "true"
+          monorepo-project: "deskto"
+
       - name: Invalid monorepo value
         id: invalid_monorepo
         continue-on-error: true
@@ -240,6 +267,9 @@ jobs:
           PRERELEASE_NO_MATCH_OUTCOME: ${{ steps.prerelease_no_match.outcome }}
           INVALID_TRIM_OUTCOME: ${{ steps.invalid_trim.outcome }}
           INVALID_PRERELEASE_OUTCOME: ${{ steps.invalid_prerelease.outcome }}
+          INVALID_PRERELEASE_SUBSTRING_OUTCOME: ${{ steps.invalid_prerelease_substring.outcome }}
+          INVALID_TRIM_SUBSTRING_OUTCOME: ${{ steps.invalid_trim_substring.outcome }}
+          INVALID_MONOREPO_PROJECT_SUBSTRING_OUTCOME: ${{ steps.invalid_monorepo_project_substring.outcome }}
           INVALID_MONOREPO_OUTCOME: ${{ steps.invalid_monorepo.outcome }}
           MONOREPO_NO_PROJECT_OUTCOME: ${{ steps.monorepo_no_project.outcome }}
           INVALID_MONOREPO_PROJECT_OUTCOME: ${{ steps.invalid_monorepo_project.outcome }}
@@ -313,6 +343,9 @@ jobs:
 
           assert_failure "Invalid trim value"                "$INVALID_TRIM_OUTCOME"
           assert_failure "Invalid prerelease value"          "$INVALID_PRERELEASE_OUTCOME"
+          assert_failure "Invalid prerelease substring 'tru'" "$INVALID_PRERELEASE_SUBSTRING_OUTCOME"
+          assert_failure "Invalid trim substring 'tru'"      "$INVALID_TRIM_SUBSTRING_OUTCOME"
+          assert_failure "Invalid monorepo-project 'deskto'" "$INVALID_MONOREPO_PROJECT_SUBSTRING_OUTCOME"
           assert_failure "Invalid monorepo value"            "$INVALID_MONOREPO_OUTCOME"
           assert_failure "Monorepo=true without project"     "$MONOREPO_NO_PROJECT_OUTCOME"
           assert_failure "Invalid monorepo-project value"    "$INVALID_MONOREPO_PROJECT_OUTCOME"

--- a/.github/workflows/test-get-release-version.yml
+++ b/.github/workflows/test-get-release-version.yml
@@ -133,6 +133,15 @@ jobs:
           repository: bitwarden/passwordless-server
           prerelease: "false"
 
+      - name: Non-monorepo, prerelease=true, trim=true
+        id: non_monorepo_prerelease_trim
+        continue-on-error: true
+        uses: ./get-release-version
+        with:
+          repository: bitwarden/passwordless-server
+          prerelease: "true"
+          trim: "true"
+
       ### No match cases ###
 
       - name: Prerelease=true with no matching pre-release
@@ -214,6 +223,8 @@ jobs:
           NON_MONOREPO_PRERELEASE_VERSION: ${{ steps.non_monorepo_prerelease.outputs.version }}
           NON_MONOREPO_STABLE_MIXED_OUTCOME: ${{ steps.non_monorepo_stable_mixed.outcome }}
           NON_MONOREPO_STABLE_MIXED_VERSION: ${{ steps.non_monorepo_stable_mixed.outputs.version }}
+          NON_MONOREPO_PRERELEASE_TRIM_OUTCOME: ${{ steps.non_monorepo_prerelease_trim.outcome }}
+          NON_MONOREPO_PRERELEASE_TRIM_VERSION: ${{ steps.non_monorepo_prerelease_trim.outputs.version }}
           PRERELEASE_NO_MATCH_OUTCOME: ${{ steps.prerelease_no_match.outcome }}
           INVALID_TRIM_OUTCOME: ${{ steps.invalid_trim.outcome }}
           INVALID_PRERELEASE_OUTCOME: ${{ steps.invalid_prerelease.outcome }}
@@ -268,18 +279,20 @@ jobs:
             fi
           }
 
-          assert_success "Non-monorepo, trim=false"     "$NON_MONOREPO_NO_TRIM_OUTCOME"     "$NON_MONOREPO_NO_TRIM_VERSION"     '^v[0-9]+\.[0-9]+\.[0-9]+'
-          assert_success "Non-monorepo, trim=true"      "$NON_MONOREPO_TRIM_OUTCOME"        "$NON_MONOREPO_TRIM_VERSION"        '^[0-9]+\.[0-9]+\.[0-9]+'
-          assert_success "Monorepo browser, trim=false" "$MONOREPO_BROWSER_NO_TRIM_OUTCOME" "$MONOREPO_BROWSER_NO_TRIM_VERSION" '^browser-v[0-9]+\.[0-9]+\.[0-9]+'
-          assert_success "Monorepo browser, trim=true"  "$MONOREPO_BROWSER_TRIM_OUTCOME"    "$MONOREPO_BROWSER_TRIM_VERSION"    '^[0-9]+\.[0-9]+\.[0-9]+'
-          assert_success "Monorepo cli, trim=false"     "$MONOREPO_CLI_OUTCOME"             "$MONOREPO_CLI_VERSION"             '^cli-v[0-9]+\.[0-9]+\.[0-9]+'
-          assert_success "Monorepo desktop, trim=false" "$MONOREPO_DESKTOP_OUTCOME"         "$MONOREPO_DESKTOP_VERSION"         '^desktop-v[0-9]+\.[0-9]+\.[0-9]+'
-          assert_success "Monorepo web, trim=false"    "$MONOREPO_WEB_NO_TRIM_OUTCOME"     "$MONOREPO_WEB_NO_TRIM_VERSION"     '^web-v[0-9]+\.[0-9]+\.[0-9]+'
-          assert_success "Monorepo web, trim=true"     "$MONOREPO_WEB_TRIM_OUTCOME"        "$MONOREPO_WEB_TRIM_VERSION"        '^[0-9]+\.[0-9]+\.[0-9]+'
-          assert_success "Non-monorepo, prerelease=false"     "$NON_MONOREPO_STABLE_OUTCOME"     "$NON_MONOREPO_STABLE_VERSION"     '^v[0-9]+\.[0-9]+\.[0-9]+'
-          assert_success "Monorepo desktop, prerelease=false" "$MONOREPO_DESKTOP_STABLE_OUTCOME" "$MONOREPO_DESKTOP_STABLE_VERSION" '^desktop-v[0-9]+\.[0-9]+\.[0-9]+'
-          assert_success "Non-monorepo, prerelease=true"      "$NON_MONOREPO_PRERELEASE_OUTCOME" "$NON_MONOREPO_PRERELEASE_VERSION" '^[0-9]+\.[0-9]+\.[0-9]+'
-          assert_success "Non-monorepo, prerelease=false on a repo with pre-releases" "$NON_MONOREPO_STABLE_MIXED_OUTCOME" "$NON_MONOREPO_STABLE_MIXED_VERSION" '^[0-9]+\.[0-9]+\.[0-9]+'
+          assert_success "Non-monorepo, trim=false"     "$NON_MONOREPO_NO_TRIM_OUTCOME"     "$NON_MONOREPO_NO_TRIM_VERSION"     '^v[0-9]+\.[0-9]+\.[0-9]+$'
+          assert_success "Non-monorepo, trim=true"      "$NON_MONOREPO_TRIM_OUTCOME"        "$NON_MONOREPO_TRIM_VERSION"        '^[0-9]+\.[0-9]+\.[0-9]+$'
+          assert_success "Monorepo browser, trim=false" "$MONOREPO_BROWSER_NO_TRIM_OUTCOME" "$MONOREPO_BROWSER_NO_TRIM_VERSION" '^browser-v[0-9]+\.[0-9]+\.[0-9]+$'
+          assert_success "Monorepo browser, trim=true"  "$MONOREPO_BROWSER_TRIM_OUTCOME"    "$MONOREPO_BROWSER_TRIM_VERSION"    '^[0-9]+\.[0-9]+\.[0-9]+$'
+          assert_success "Monorepo cli, trim=false"     "$MONOREPO_CLI_OUTCOME"             "$MONOREPO_CLI_VERSION"             '^cli-v[0-9]+\.[0-9]+\.[0-9]+$'
+          assert_success "Monorepo desktop, trim=false" "$MONOREPO_DESKTOP_OUTCOME"         "$MONOREPO_DESKTOP_VERSION"         '^desktop-v[0-9]+\.[0-9]+\.[0-9]+$'
+          assert_success "Monorepo web, trim=false"    "$MONOREPO_WEB_NO_TRIM_OUTCOME"     "$MONOREPO_WEB_NO_TRIM_VERSION"     '^web-v[0-9]+\.[0-9]+\.[0-9]+$'
+          assert_success "Monorepo web, trim=true"     "$MONOREPO_WEB_TRIM_OUTCOME"        "$MONOREPO_WEB_TRIM_VERSION"        '^[0-9]+\.[0-9]+\.[0-9]+$'
+          assert_success "Non-monorepo, prerelease=false"     "$NON_MONOREPO_STABLE_OUTCOME"     "$NON_MONOREPO_STABLE_VERSION"     '^v[0-9]+\.[0-9]+\.[0-9]+$'
+          assert_success "Monorepo desktop, prerelease=false" "$MONOREPO_DESKTOP_STABLE_OUTCOME" "$MONOREPO_DESKTOP_STABLE_VERSION" '^desktop-v[0-9]+\.[0-9]+\.[0-9]+$'
+          # Pre-release tags may carry a suffix (e.g. 2025.10.0-beta.1), so this pattern allows one.
+          assert_success "Non-monorepo, prerelease=true"      "$NON_MONOREPO_PRERELEASE_OUTCOME" "$NON_MONOREPO_PRERELEASE_VERSION" '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'
+          assert_success "Non-monorepo, prerelease=true, trim=true" "$NON_MONOREPO_PRERELEASE_TRIM_OUTCOME" "$NON_MONOREPO_PRERELEASE_TRIM_VERSION" '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'
+          assert_success "Non-monorepo, prerelease=false on a repo with pre-releases" "$NON_MONOREPO_STABLE_MIXED_OUTCOME" "$NON_MONOREPO_STABLE_MIXED_VERSION" '^[0-9]+\.[0-9]+\.[0-9]+$'
 
           assert_differs "prerelease=true and prerelease=false resolve differently" "$NON_MONOREPO_PRERELEASE_VERSION" "$NON_MONOREPO_STABLE_MIXED_VERSION"
 

--- a/.github/workflows/test-get-release-version.yml
+++ b/.github/workflows/test-get-release-version.yml
@@ -97,6 +97,24 @@ jobs:
           monorepo: "true"
           monorepo-project: web
 
+      - name: Non-monorepo, prerelease=false
+        id: non_monorepo_stable
+        continue-on-error: true
+        uses: ./get-release-version
+        with:
+          repository: bitwarden/server
+          prerelease: "false"
+
+      - name: Monorepo desktop, prerelease=false
+        id: monorepo_desktop_stable
+        continue-on-error: true
+        uses: ./get-release-version
+        with:
+          repository: bitwarden/clients
+          monorepo: "true"
+          monorepo-project: desktop
+          prerelease: "false"
+
       ### Invalid cases ###
 
       - name: Invalid trim value
@@ -106,6 +124,14 @@ jobs:
         with:
           repository: bitwarden/server
           trim: "maybe"
+
+      - name: Invalid prerelease value
+        id: invalid_prerelease
+        continue-on-error: true
+        uses: ./get-release-version
+        with:
+          repository: bitwarden/server
+          prerelease: "maybe"
 
       - name: Invalid monorepo value
         id: invalid_monorepo
@@ -152,7 +178,12 @@ jobs:
           MONOREPO_WEB_NO_TRIM_VERSION: ${{ steps.monorepo_web_no_trim.outputs.version }}
           MONOREPO_WEB_TRIM_OUTCOME: ${{ steps.monorepo_web_trim.outcome }}
           MONOREPO_WEB_TRIM_VERSION: ${{ steps.monorepo_web_trim.outputs.version }}
+          NON_MONOREPO_STABLE_OUTCOME: ${{ steps.non_monorepo_stable.outcome }}
+          NON_MONOREPO_STABLE_VERSION: ${{ steps.non_monorepo_stable.outputs.version }}
+          MONOREPO_DESKTOP_STABLE_OUTCOME: ${{ steps.monorepo_desktop_stable.outcome }}
+          MONOREPO_DESKTOP_STABLE_VERSION: ${{ steps.monorepo_desktop_stable.outputs.version }}
           INVALID_TRIM_OUTCOME: ${{ steps.invalid_trim.outcome }}
+          INVALID_PRERELEASE_OUTCOME: ${{ steps.invalid_prerelease.outcome }}
           INVALID_MONOREPO_OUTCOME: ${{ steps.invalid_monorepo.outcome }}
           MONOREPO_NO_PROJECT_OUTCOME: ${{ steps.monorepo_no_project.outcome }}
           INVALID_MONOREPO_PROJECT_OUTCOME: ${{ steps.invalid_monorepo_project.outcome }}
@@ -199,8 +230,11 @@ jobs:
           assert_success "Monorepo desktop, trim=false" "$MONOREPO_DESKTOP_OUTCOME"         "$MONOREPO_DESKTOP_VERSION"         '^desktop-v[0-9]+\.[0-9]+\.[0-9]+'
           assert_success "Monorepo web, trim=false"    "$MONOREPO_WEB_NO_TRIM_OUTCOME"     "$MONOREPO_WEB_NO_TRIM_VERSION"     '^web-v[0-9]+\.[0-9]+\.[0-9]+'
           assert_success "Monorepo web, trim=true"     "$MONOREPO_WEB_TRIM_OUTCOME"        "$MONOREPO_WEB_TRIM_VERSION"        '^[0-9]+\.[0-9]+\.[0-9]+'
+          assert_success "Non-monorepo, prerelease=false"     "$NON_MONOREPO_STABLE_OUTCOME"     "$NON_MONOREPO_STABLE_VERSION"     '^v[0-9]+\.[0-9]+\.[0-9]+'
+          assert_success "Monorepo desktop, prerelease=false" "$MONOREPO_DESKTOP_STABLE_OUTCOME" "$MONOREPO_DESKTOP_STABLE_VERSION" '^desktop-v[0-9]+\.[0-9]+\.[0-9]+'
 
           assert_failure "Invalid trim value"                "$INVALID_TRIM_OUTCOME"
+          assert_failure "Invalid prerelease value"          "$INVALID_PRERELEASE_OUTCOME"
           assert_failure "Invalid monorepo value"            "$INVALID_MONOREPO_OUTCOME"
           assert_failure "Monorepo=true without project"     "$MONOREPO_NO_PROJECT_OUTCOME"
           assert_failure "Invalid monorepo-project value"    "$INVALID_MONOREPO_PROJECT_OUTCOME"

--- a/.github/workflows/test-get-release-version.yml
+++ b/.github/workflows/test-get-release-version.yml
@@ -115,6 +115,34 @@ jobs:
           monorepo-project: desktop
           prerelease: "false"
 
+      # bitwarden/passwordless-server has both stable and pre-releases, and its
+      # newest release is a pre-release, so the two filters resolve to different tags.
+      - name: Non-monorepo, prerelease=true
+        id: non_monorepo_prerelease
+        continue-on-error: true
+        uses: ./get-release-version
+        with:
+          repository: bitwarden/passwordless-server
+          prerelease: "true"
+
+      - name: Non-monorepo, prerelease=false on a repo with pre-releases
+        id: non_monorepo_stable_mixed
+        continue-on-error: true
+        uses: ./get-release-version
+        with:
+          repository: bitwarden/passwordless-server
+          prerelease: "false"
+
+      ### No match cases ###
+
+      - name: Prerelease=true with no matching pre-release
+        id: prerelease_no_match
+        continue-on-error: true
+        uses: ./get-release-version
+        with:
+          repository: bitwarden/server
+          prerelease: "true"
+
       ### Invalid cases ###
 
       - name: Invalid trim value
@@ -182,6 +210,11 @@ jobs:
           NON_MONOREPO_STABLE_VERSION: ${{ steps.non_monorepo_stable.outputs.version }}
           MONOREPO_DESKTOP_STABLE_OUTCOME: ${{ steps.monorepo_desktop_stable.outcome }}
           MONOREPO_DESKTOP_STABLE_VERSION: ${{ steps.monorepo_desktop_stable.outputs.version }}
+          NON_MONOREPO_PRERELEASE_OUTCOME: ${{ steps.non_monorepo_prerelease.outcome }}
+          NON_MONOREPO_PRERELEASE_VERSION: ${{ steps.non_monorepo_prerelease.outputs.version }}
+          NON_MONOREPO_STABLE_MIXED_OUTCOME: ${{ steps.non_monorepo_stable_mixed.outcome }}
+          NON_MONOREPO_STABLE_MIXED_VERSION: ${{ steps.non_monorepo_stable_mixed.outputs.version }}
+          PRERELEASE_NO_MATCH_OUTCOME: ${{ steps.prerelease_no_match.outcome }}
           INVALID_TRIM_OUTCOME: ${{ steps.invalid_trim.outcome }}
           INVALID_PRERELEASE_OUTCOME: ${{ steps.invalid_prerelease.outcome }}
           INVALID_MONOREPO_OUTCOME: ${{ steps.invalid_monorepo.outcome }}
@@ -210,6 +243,19 @@ jobs:
             fi
           }
 
+          function assert_differs() {
+            local name="$1"
+            local first="$2"
+            local second="$3"
+
+            if [[ "$first" == "$second" ]]; then
+              echo "${name}: FAIL (both filters resolved to '${first}')"
+              test_failures+=("$name")
+            else
+              echo "${name}: pass (prerelease=${first}, stable=${second})"
+            fi
+          }
+
           function assert_failure() {
             local name="$1"
             local outcome="$2"
@@ -232,6 +278,12 @@ jobs:
           assert_success "Monorepo web, trim=true"     "$MONOREPO_WEB_TRIM_OUTCOME"        "$MONOREPO_WEB_TRIM_VERSION"        '^[0-9]+\.[0-9]+\.[0-9]+'
           assert_success "Non-monorepo, prerelease=false"     "$NON_MONOREPO_STABLE_OUTCOME"     "$NON_MONOREPO_STABLE_VERSION"     '^v[0-9]+\.[0-9]+\.[0-9]+'
           assert_success "Monorepo desktop, prerelease=false" "$MONOREPO_DESKTOP_STABLE_OUTCOME" "$MONOREPO_DESKTOP_STABLE_VERSION" '^desktop-v[0-9]+\.[0-9]+\.[0-9]+'
+          assert_success "Non-monorepo, prerelease=true"      "$NON_MONOREPO_PRERELEASE_OUTCOME" "$NON_MONOREPO_PRERELEASE_VERSION" '^[0-9]+\.[0-9]+\.[0-9]+'
+          assert_success "Non-monorepo, prerelease=false on a repo with pre-releases" "$NON_MONOREPO_STABLE_MIXED_OUTCOME" "$NON_MONOREPO_STABLE_MIXED_VERSION" '^[0-9]+\.[0-9]+\.[0-9]+'
+
+          assert_differs "prerelease=true and prerelease=false resolve differently" "$NON_MONOREPO_PRERELEASE_VERSION" "$NON_MONOREPO_STABLE_MIXED_VERSION"
+
+          assert_failure "Prerelease=true with no matching pre-release" "$PRERELEASE_NO_MATCH_OUTCOME"
 
           assert_failure "Invalid trim value"                "$INVALID_TRIM_OUTCOME"
           assert_failure "Invalid prerelease value"          "$INVALID_PRERELEASE_OUTCOME"

--- a/get-release-version/action.yml
+++ b/get-release-version/action.yml
@@ -107,6 +107,11 @@ runs:
               ;;
           esac
 
+        if [[ -z "$LATEST_RELEASE_TAG_VERSION" ]]; then
+          echo "[!] No release found for '$REPOSITORY' matching prerelease='${INPUT_PRERELEASE}' monorepo-project='${INPUT_MONOREPO_PROJECT}'"
+          exit 1
+        fi
+
         case "${INPUT_TRIM}" in
             "true")
               LATEST_RELEASE_TAG_VERSION=$(echo "${LATEST_RELEASE_TAG_VERSION//[a-z-]}")

--- a/get-release-version/action.yml
+++ b/get-release-version/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: "Identifies the monorepo project: ('', 'browser', 'cli', 'desktop', 'web')"
     required: false
     default: ""
+  prerelease:
+    description: "Filter by release type: 'false' (default) = latest stable release, 'true' = latest pre-release, '' = most recent regardless (legacy). 'true'/'false' exclude drafts."
+    required: false
+    default: "false"
 outputs:
   version:
     description: "GitHub Latest Release version from specified repository"
@@ -31,10 +35,16 @@ runs:
         INPUT_TRIM: ${{ inputs.trim }}
         INPUT_MONOREPO: ${{ inputs.monorepo }}
         INPUT_MONOREPO_PROJECT: ${{ inputs.monorepo-project }}
+        INPUT_PRERELEASE: ${{ inputs.prerelease }}
       run: |
         trim_valid_inputs=("true" "false")
         if [[ ! "${trim_valid_inputs[@]}" =~ "${INPUT_TRIM}" ]]; then
           echo "[!] 'trim' option only supports the following values: (${trim_valid_inputs})"
+          exit 1
+        fi
+        prerelease_valid_inputs=("" "true" "false")
+        if [[ ! "${prerelease_valid_inputs[@]}" =~ "${INPUT_PRERELEASE}" ]]; then
+          echo "[!] 'prerelease' option only supports the following values: ('', 'true', 'false')"
           exit 1
         fi
         monorepo_valid_inputs=("true" "false")
@@ -71,18 +81,28 @@ runs:
         INPUT_TRIM: ${{ inputs.trim }}
         INPUT_MONOREPO: ${{ inputs.monorepo }}
         INPUT_MONOREPO_PROJECT: ${{ inputs.monorepo-project }}
+        INPUT_PRERELEASE: ${{ inputs.prerelease }}
       run: |
+        # Optional release-type filter
+        case "${INPUT_PRERELEASE}" in
+            "true")  SELECT='select(.isPrerelease and (.isDraft | not))' ;;
+            "false") SELECT='select((.isPrerelease | not) and (.isDraft | not))' ;;
+            *)       SELECT='.' ;;
+          esac
+
         case "${INPUT_MONOREPO}" in
             "true")
               LATEST_RELEASE_TAG_VERSION=$(
                 gh release list --repo "$REPOSITORY" --limit 100 --order desc \
-                  --json tagName --jq "[.[].tagName | select(startswith(\"$INPUT_MONOREPO_PROJECT\"))][0]"
+                  --json tagName,isPrerelease,isDraft \
+                  --jq "[.[] | select(.tagName | startswith(\"$INPUT_MONOREPO_PROJECT\")) | $SELECT | .tagName][0] // \"\""
               )
               ;;
             "false")
               LATEST_RELEASE_TAG_VERSION=$(
-                gh release list --repo "$REPOSITORY" --limit 1 \
-                  --json tagName --jq '.[0].tagName'
+                gh release list --repo "$REPOSITORY" --limit 100 --order desc \
+                  --json tagName,isPrerelease,isDraft \
+                  --jq "[.[] | $SELECT | .tagName][0] // \"\""
               )
               ;;
           esac

--- a/get-release-version/action.yml
+++ b/get-release-version/action.yml
@@ -114,8 +114,9 @@ runs:
 
         case "${INPUT_TRIM}" in
             "true")
-              LATEST_RELEASE_TAG_VERSION=$(echo "${LATEST_RELEASE_TAG_VERSION//[a-z-]}")
-                echo "version=$LATEST_RELEASE_TAG_VERSION" >> $GITHUB_OUTPUT
+              LATEST_RELEASE_TAG_VERSION="${LATEST_RELEASE_TAG_VERSION#"$INPUT_MONOREPO_PROJECT"-}"
+              LATEST_RELEASE_TAG_VERSION="${LATEST_RELEASE_TAG_VERSION#v}"
+              echo "version=$LATEST_RELEASE_TAG_VERSION" >> $GITHUB_OUTPUT
               ;;
             "false")
               echo "version=$LATEST_RELEASE_TAG_VERSION" >> $GITHUB_OUTPUT

--- a/get-release-version/action.yml
+++ b/get-release-version/action.yml
@@ -37,30 +37,38 @@ runs:
         INPUT_MONOREPO_PROJECT: ${{ inputs.monorepo-project }}
         INPUT_PRERELEASE: ${{ inputs.prerelease }}
       run: |
-        trim_valid_inputs=("true" "false")
-        if [[ ! "${trim_valid_inputs[@]}" =~ "${INPUT_TRIM}" ]]; then
-          echo "[!] 'trim' option only supports the following values: (${trim_valid_inputs})"
-          exit 1
-        fi
-        prerelease_valid_inputs=("" "true" "false")
-        if [[ ! "${prerelease_valid_inputs[@]}" =~ "${INPUT_PRERELEASE}" ]]; then
-          echo "[!] 'prerelease' option only supports the following values: ('', 'true', 'false')"
-          exit 1
-        fi
-        monorepo_valid_inputs=("true" "false")
-        if [[ ! "${monorepo_valid_inputs[@]}" =~ "${INPUT_MONOREPO}" ]]; then
-          echo "[!] 'monorepo' option only supports the following values: (${monorepo_valid_inputs})"
-          exit 1
-        fi
+        case "${INPUT_TRIM}" in
+          "true" | "false") ;;
+          *)
+            echo "[!] 'trim' option only supports the following values: ('true', 'false')"
+            exit 1
+            ;;
+        esac
+        case "${INPUT_PRERELEASE}" in
+          "" | "true" | "false") ;;
+          *)
+            echo "[!] 'prerelease' option only supports the following values: ('', 'true', 'false')"
+            exit 1
+            ;;
+        esac
+        case "${INPUT_MONOREPO}" in
+          "true" | "false") ;;
+          *)
+            echo "[!] 'monorepo' option only supports the following values: ('true', 'false')"
+            exit 1
+            ;;
+        esac
         if [ "${INPUT_MONOREPO}" == "true" ] && [ "${INPUT_MONOREPO_PROJECT}" == "" ]; then
           echo "[!] using the 'monorepo' option requires the use of 'monorepo-project'"
           exit 1
         fi
-        monorepo_project_valid_inputs=("" "browser" "cli" "desktop" "web")
-        if [[ ! "${monorepo_project_valid_inputs[@]}" =~ "${INPUT_MONOREPO_PROJECT}" ]]; then
-          echo "[!] 'monorepo-project' option only supports the following values: (${monorepo_project_valid_inputs})"
-          exit 1
-        fi
+        case "${INPUT_MONOREPO_PROJECT}" in
+          "" | "browser" | "cli" | "desktop" | "web") ;;
+          *)
+            echo "[!] 'monorepo-project' option only supports the following values: ('', 'browser', 'cli', 'desktop', 'web')"
+            exit 1
+            ;;
+        esac
 
     - name: Check Runner OS
       shell: bash

--- a/get-release-version/action.yml
+++ b/get-release-version/action.yml
@@ -20,7 +20,7 @@ inputs:
   prerelease:
     description: "Filter by release type: 'false' (default) = latest stable release, 'true' = latest pre-release, '' = most recent regardless (legacy). 'true'/'false' exclude drafts."
     required: false
-    default: "false"
+    default: ""
 outputs:
   version:
     description: "GitHub Latest Release version from specified repository"

--- a/get-release-version/action.yml
+++ b/get-release-version/action.yml
@@ -114,7 +114,7 @@ runs:
 
         case "${INPUT_TRIM}" in
             "true")
-              LATEST_RELEASE_TAG_VERSION=$(echo "${LATEST_RELEASE_TAG_VERSION//[a-z-]}")
+              LATEST_RELEASE_TAG_VERSION="${LATEST_RELEASE_TAG_VERSION#"${LATEST_RELEASE_TAG_VERSION%%[0-9]*}"}"
                 echo "version=$LATEST_RELEASE_TAG_VERSION" >> $GITHUB_OUTPUT
               ;;
             "false")

--- a/get-release-version/action.yml
+++ b/get-release-version/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: ""
   prerelease:
-    description: "Filter by release type: 'false' (default) = latest stable release, 'true' = latest pre-release, '' = most recent regardless (legacy). 'true'/'false' exclude drafts."
+    description: "Filter by release type: 'false' = latest stable release, 'true' = latest pre-release, '' = most recent regardless (legacy). 'true'/'false' exclude drafts."
     required: false
     default: ""
 outputs:

--- a/get-release-version/action.yml
+++ b/get-release-version/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: "This is the repository that we get the latest release version from"
     required: true
   trim:
-    description: "Trims the returned value of all letter characters: ('true', 'false')"
+    description: "Strips any tag prefix before the version number, keeping any pre-release suffix, e.g. 'desktop-v2026.10.0-beta.1' -> '2026.10.0-beta.1': ('true', 'false')"
     required: false
     default: "false"
   monorepo:

--- a/get-release-version/action.yml
+++ b/get-release-version/action.yml
@@ -18,9 +18,9 @@ inputs:
     required: false
     default: ""
   prerelease:
-    description: "Filter by release type: 'false' = latest stable release, 'true' = latest pre-release, '' = most recent regardless (legacy). 'true'/'false' exclude drafts."
+    description: "Filter by release type: 'false' (default) = latest stable release, 'true' = latest pre-release, '' = most recent regardless of type. 'true'/'false' exclude drafts."
     required: false
-    default: ""
+    default: "false"
 outputs:
   version:
     description: "GitHub Latest Release version from specified repository"


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-2104](https://bitwarden.atlassian.net/browse/BRE-2104)

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, describe the impact and migration path for users of these workflows and shared composite actions.

For this repo, breaking changes can include renamed inputs/outputs, changed defaults, removed steps, or behavior changes that alter workflow results.

For breaking changes:
1. Describe what changed in the workflow or action interface
2. Explain why the change was necessary
3. Provide migration steps and timeline (if any)
4. Link to any paired PRs in consuming repos (if relevant)

Otherwise, you can remove this section. -->


[BRE-2104]: https://bitwarden.atlassian.net/browse/BRE-2104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ