### PR TITLE
[BRE-2094] Add _publish-passwordless-nodejs-npm.yml workflow

### DIFF
--- a/.github/workflows/_publish-passwordless-nodejs-npm.yml
+++ b/.github/workflows/_publish-passwordless-nodejs-npm.yml
@@ -1,0 +1,97 @@
+name: _publish-passwordless-nodejs-npm
+run-name: Publish @passwordlessdev/passwordless-nodejs to npm
+
+# Reusable publish logic for @passwordlessdev/passwordless-nodejs, called by
+# bitwarden/passwordless-nodejs' inert publish.yml shim. Living here (locked main, no
+# external contributors) is what lets the shim reference it @main so CD can iterate
+# independently of the CI-built artifact.
+#
+# Runs in the caller's repo context (bitwarden/passwordless-nodejs) at the dispatched
+# commit — the publish-release/<version> branch deploy cuts from the release commit. The
+# version is derived from that commit's package.json (single source of truth; npm publishes
+# that version regardless), and the matching CI-built artifact is promoted from the
+# <version> GitHub Release — never rebuilt here.
+#
+# Provenance is issued by npm's trusted publisher only for this exact
+# repo + workflow (publish.yml) + environment (passwordless-nodejs-npm); keep this job free
+# of any other OIDC login (e.g. Azure) so the environment-scoped id-token is used solely
+# for npm.
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Publish @passwordlessdev/passwordless-nodejs to npm
+    runs-on: ubuntu-24.04
+    environment: passwordless-nodejs-npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      # Defense-in-depth: this publish must only ever run from a dispatch by the BRE deploy
+      # bot. If someone runs the passwordless-nodejs publish.yml shim by hand (e.g. on main,
+      # or re-dispatches an existing publish-release branch), fail fast before touching the
+      # registry. This is a backstop to the primary controls (environment branch policy +
+      # publish-release ruleset).
+      - name: Verify the run was triggered by the deploy bot
+        env:
+          _TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        run: |
+          if [[ "$_TRIGGERING_ACTOR" != "bre-deploy[bot]" ]]; then
+            echo "::error::Publish must be triggered by bre-deploy[bot]; got '${_TRIGGERING_ACTOR}'"
+            exit 1
+          fi
+
+      # A bare checkout defaults to the CALLER repo (github.* is the caller's context), which
+      # is bitwarden/passwordless-nodejs when invoked via its publish.yml shim. Pin it
+      # explicitly so it is also correct from any test caller. github.sha is the caller's
+      # commit — the publish-release/<version> branch deploy cuts from the release commit.
+      - name: Check out bitwarden/passwordless-nodejs at the release commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: bitwarden/passwordless-nodejs
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Derive version from package.json
+        id: version
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
+            echo "::error::Could not read .version from package.json"
+            exit 1
+          fi
+          echo "Resolved version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 20
+          registry-url: "https://registry.npmjs.org/"
+
+      - name: Pin npm version
+        run: |
+          npm install -g npm@latest # npm 11.5.1+ required for OIDC trusted publishing + provenance
+          npm --version
+
+      # Promote the CI-built bundle: download the build zip attached to the <version>
+      # GitHub Release and unpack it into the checked-out working tree. package.json .files
+      # ships only dist/*; npm force-includes README.md + LICENSE + package.json from the
+      # working tree (already present via the checkout). passwordless-nodejs is public, so
+      # the job's GITHUB_TOKEN (contents: read) can download the release asset.
+      - name: Download and unpack npm build
+        env:
+          GH_TOKEN: ${{ github.token }}
+          _PKG_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh release download "${_PKG_VERSION}" \
+            --repo bitwarden/passwordless-nodejs \
+            --pattern "passwordless-nodejs-${_PKG_VERSION}-npm-build.zip"
+          unzip "passwordless-nodejs-${_PKG_VERSION}-npm-build.zip"
+
+      - name: Publish to npm with provenance
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-2094](https://bitwarden.atlassian.net/browse/BRE-2094)

## 📔 Objective

This PR adds the `_publish-passwordless-nodejs-npm` workflow for securely publishing the `@passwordlessdev/passwordless-nodejs` package to NPM with provenance.

[BRE-2094]: https://bitwarden.atlassian.net/browse/BRE-2094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ