### PR TITLE
fix: skip AI code review on closed and merged pull requests

### DIFF
--- a/check-review-gate/README.md
+++ b/check-review-gate/README.md
@@ -4,7 +4,9 @@ Determines whether an AI-powered code review should run on a pull request. The `
 
 ## How It Works
 
-The gate evaluates two paths in order:
+The gate evaluates three paths in order:
+
+**State check**: If the PR is closed or merged, the gate skips. Nothing about a PR that is no longer open warrants a review, and neither label overrides this.
 
 **Label path**: If the PR carries `ai-review-vnext` or `ai-review`, the review proceeds immediately without validating the at-least-one rule.
 

--- a/check-review-gate/action.yml
+++ b/check-review-gate/action.yml
@@ -63,7 +63,20 @@ runs:
           exit 1
         fi
 
-        PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json isDraft,labels)
+        PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json isDraft,labels,state)
+
+        # No review path applies to a PR that is no longer open. Labels can be added to closed and
+        # merged PRs, and pushing to the head branch of a closed PR still fires 'synchronize', so
+        # this check precedes the label path rather than sitting alongside the safety net.
+        STATE=$(echo "$PR_JSON" | jq -r '.state')
+        if [ "$STATE" != "OPEN" ]; then
+          echo "should_review=false" >> "$GITHUB_OUTPUT"
+          echo "review_variant=" >> "$GITHUB_OUTPUT"
+          echo "skip_reason=PR is not open (state: ${STATE})" >> "$GITHUB_OUTPUT"
+          echo "⚠️ Gate: PR state is ${STATE} — skipping review"
+          exit 0
+        fi
+
         LABELS=$(echo "$PR_JSON" | jq -r '.labels[].name')
 
         if printf '%s\n' "$LABELS" | grep -Fxq "ai-review-vnext"; then

--- a/review-code/README.md
+++ b/review-code/README.md
@@ -57,7 +57,8 @@ The calling workflow must grant the following GitHub permissions to the `_review
 ## Features
 
 - **Safety net**: Runs automatically when a PR is opened, converted from draft, or reopened — no label required. Skips if a review comment already exists (idempotency guard).
-- **On-demand label triggers**: Adding `ai-review` runs the current review variant; `ai-review-vnext` runs the next-generation variant. Label triggers bypass draft status and the idempotency guard.
+- **On-demand label triggers**: Adding `ai-review` runs the current review variant; `ai-review-vnext` runs the next-generation variant. Label triggers bypass draft status and the idempotency guard, but not the state check.
+- **Open PRs only**: Closed and merged PRs are never reviewed, regardless of labels. This covers labeling a closed PR and pushing to the head branch of one.
 - Uses a sticky comment — Claude updates a single comment rather than posting new ones
 - Loads Bitwarden's internal plugins: `bitwarden-code-review`, `bitwarden-software-engineer`, `bitwarden-security-engineer`, and `claude-config-validator`
 - Claude's tool access includes file reading (`Read`, `Grep`, `Glob`), git history (`git diff`, `git log`, `git show`), and PR interaction (`gh pr view/diff/checks`, inline comments)
@@ -75,5 +76,6 @@ The calling workflow must grant the following GitHub permissions to the `_review
 | No review after adding `ai-review` label | Actor lacks write permission, or the calling workflow does not trigger on `labeled` events                                                |
 | Safety net ran but review was skipped    | A sticky comment with the review marker already exists from a prior run (idempotency guard)                                               |
 | Review skipped on a draft PR             | Expected — the safety net does not run on drafts. Add the `ai-review` label to force a review on a draft.                                 |
+| No review after labeling a closed PR     | Expected — closed and merged PRs are never reviewed. Reopen the PR first.                                                                 |
 | Workflow fails at secret retrieval       | Azure credentials are missing or the calling workflow did not pass the required secrets                                                   |
 | Claude response stops mid-way            | 10-minute step timeout was hit; consider breaking the request into smaller tasks                                                          |


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.slack.com/archives/C0B44P2J5FB/p1785932826113439

## 📔 Objective

Users reported AI code reviews running on closed pull requests. `check-review-gate` fetched `isDraft` and `labels` from the PR but never looked at its state, so two paths let a closed PR through:

- Labeling a closed PR works, because the label path short-circuits to `should_review=true` ahead of every other check and GitHub still allows labels after a PR closes. The consumer template triggers on `labeled`.
- Pushing to a closed PR's branch fires `synchronize`, and since labels persist through close, that re-enters the label path.

The fix adds `state` to the existing `gh pr view --json` call and skips when it isn't `OPEN`, so it costs no additional API call. It sits ahead of the label path on purpose, so no label can override it.

It also covers a race the old code lost quietly: if a PR closed while its `opened` run sat in the queue, the review ran anyway.

Verified by running the extracted script against live PRs in this repo:

| PR | State | Event | Result |
| --- | --- | --- | --- |
| #861 | MERGED | `labeled` | skipped |
| #837 | CLOSED | `labeled` | skipped |
| #858 | OPEN, carries `ai-review` | `labeled` | reviews, unchanged |
| #858 | OPEN, carries `ai-review` | `synchronize` | reviews, unchanged |
| #857 | OPEN | `opened` | safety net, unchanged |

Both READMEs are updated, including a troubleshooting row for the closed-PR case.

## 🚨 Breaking Changes

One behavior change, with no migration needed: labeling a closed or merged PR with `ai-review` no longer triggers a review, so reopen the PR first if you want one. Every other path behaves as before.
