### PR TITLE
feat: add org-wide entry point for AI configuration validation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -181,6 +181,19 @@ For containerized actions (e.g., `version-bump`):
 - Use environment variables for input (`os.getenv("INPUT_*")`)
 - Docker-based execution via `Dockerfile`
 
+**Workflow Files:**
+
+- `_[name].yml` - Reusable workflow (`on: workflow_call`) called by this repo and others
+- `[name].yml` - This repository's own CI
+- `test-[action-name].yml` - Test harness for a single action
+- `org-[name].yml` - Entry point for an organization-wide ruleset; runs in every repo in the org rather than here
+
+Organization-wide workflows (`org-*.yml`) carry three hard constraints:
+
+- Must sit directly in `.github/workflows/`. GitHub does not discover workflows in subdirectories, so these cannot be filed away in their own folder
+- Must trigger on `pull_request`. Rulesets also accept `pull_request_target`, which grants secrets to pull requests from forks
+- Must reference reusable workflows by full `bitwarden/gh-actions/...@main` path. A `./` path resolves against the target repository, which has no such file
+
 **Testing:**
 
 - Test workflows named `test-[action-name].yml`

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,5 +18,6 @@
 .github/workflows/_respond.yml @bitwarden/team-ai-sme
 .github/workflows/_review-code.yml @bitwarden/team-ai-sme
 .github/workflows/_validate-ai.yml @bitwarden/team-ai-sme
+.github/workflows/org-validate-ai.yml @bitwarden/team-ai-sme
 .github/workflows/respond.yml @bitwarden/team-ai-sme
 .github/workflows/review-code.yml @bitwarden/team-ai-sme

--- a/.github/workflows/org-validate-ai.yml
+++ b/.github/workflows/org-validate-ai.yml
@@ -1,0 +1,22 @@
+name: Validate AI
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  validate:
+    name: Validate
+    # Do not run this workflow in the gh-actions repository itself
+    if: github.repository != 'bitwarden/gh-actions'
+    uses: bitwarden/gh-actions/.github/workflows/_validate-ai.yml@main
+    secrets:
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      pull-requests: write

--- a/.github/workflows/org-validate-ai.yml
+++ b/.github/workflows/org-validate-ai.yml
@@ -1,4 +1,4 @@
-name: Validate AI
+name: Validate AI Configuration
 
 on:
   pull_request:


### PR DESCRIPTION
## 🎟️ Tracking

Setup for running AI configuration validation across the whole organization.

## 📔 Objective

Adds `org-validate-ai.yml`, the entry point for running AI configuration validation on every repository in the organization. Repositories will no longer need a caller workflow of their own.

`validate-ai` suits org-wide application because it decides for itself whether to do anything. The change-detection step in `validate-ai/action.yml` diffs the pull request against its base ref and exits clean when no Claude-related file changed, so enabling it everywhere costs nothing in repositories with no Claude configuration. There is no label or opt-in flag to wire up.

`_validate-ai.yml` is untouched, so existing per-repo callers keep working while the rollout proceeds.

### The new workflow

Triggers on `pull_request` and calls `_validate-ai.yml` by full `bitwarden/gh-actions/...@main` path. A `./` reference would resolve against the target repository, which has no such file. The `if:` guard keeps it from running in `gh-actions` itself, and `gh-actions` will also be excluded from the ruleset's target repositories.

The trigger must stay `pull_request`. Rulesets also accept `pull_request_target`, which grants secrets to pull requests from forks and would put a live Anthropic API key on a runner alongside untrusted contributor code.

### Conventions

`.claude/CLAUDE.md` now documents the four workflow naming patterns in this repo and the three constraints specific to `org-*.yml`: flat placement in `.github/workflows/` (GitHub does not discover workflows in subdirectories), `pull_request` only, and full-path reusable workflow references. This is the first `org-*.yml` file, so the convention is worth stating before there are more.

### Rollout

1. Canary: one repository, ruleset in Evaluate mode. Confirm the OIDC exchange and Key Vault retrieval work. GitHub does not document which repository's secrets a ruleset-sourced workflow can read, so this verifies the assumption the rest depends on.
2. Evaluate across all repositories for a week. Watch for repositories where the workflow errors rather than skipping, and watch Anthropic spend, which now scales with org-wide pull request volume.
3. Flip enforcement to Active.
4. Delete the per-repository caller workflows.

### Setup required from IT

Every repository in the organization must be able to read `ANTHROPIC-CODE-REVIEW-API-KEY` from the `gh-org-bitwarden` Key Vault over the existing OIDC path. That trust is currently scoped per repository.

`AZURE_SUBSCRIPTION_ID`, `AZURE_TENANT_ID`, and `AZURE_CLIENT_ID` must exist as organization secrets with visibility set to all repositories. Key Vault authorization should grant get on that one secret, on an identity dedicated to validation.
