### PR TITLE
fix: read PR Claude config from .claude-pr and retry the summary write

### DIFF
--- a/validate-ai/README.md
+++ b/validate-ai/README.md
@@ -119,6 +119,18 @@ The structure, marketplace, and version-bump steps run the bundled scripts again
 
 The AI-driven step and its sticky PR comment fire only when a component changed (an agent, skill, command, hook, `CLAUDE.md`, or a `.claude/` file). A pull request that touches only a plugin's `plugin.json` or `README.md`, or only the marketplace manifest, is still validated by the bundled scripts, but the outcome shows up in the job log and the check status rather than in a PR comment.
 
+### Where the AI step reads Claude configuration
+
+`claude-code-action` treats PR-authored Claude configuration as untrusted, because `.claude/settings.json`, `.mcp.json`, and hooks execute at CLI startup before any tool-permission gating. Before the review runs, it replaces these repository-root paths with their base-branch versions:
+
+`.claude/`, `CLAUDE.md`, `CLAUDE.local.md`, `.mcp.json`, `.claude.json`, `.gitmodules`, `.ripgreprc`, `.husky`
+
+It snapshots the PR-authored versions to `.claude-pr/` first, preserving the original layout, so the PR's `.claude/CLAUDE.md` is available at `.claude-pr/.claude/CLAUDE.md`.
+
+The review prompt therefore directs the AI step to read those paths from `.claude-pr/` and to report them under their original repo-relative names. Reading them from the working tree yields base-branch content, which produces findings about lines the contributor never wrote. Everything outside that list, including `plugins/`, `.claude-plugin/`, and `scripts/`, is untouched and is read from the working tree.
+
+If a future version of `claude-code-action` stops writing the `.claude-pr/` snapshot, the prompt instructs the AI step to say so in its report rather than silently reviewing base-branch content.
+
 ## Bundled Scripts
 
 [`scripts/`](scripts/) is the sole source for the marketplace validation logic:

--- a/validate-ai/action.yml
+++ b/validate-ai/action.yml
@@ -338,6 +338,66 @@ runs:
           have not written this file, you have not completed the task, no matter
           what you reported in your responses.
 
+    - name: Check for a missing validation summary
+      id: summary-check
+      if: "!cancelled() && steps.changed-files.outputs.has_components == 'true'"
+      shell: bash
+      env:
+        SESSION_ID: ${{ steps.components.outputs.session_id }}
+      run: |
+        # The retry below needs this as a step output, because an `if:` on a
+        # `uses:` step cannot test the filesystem itself.
+        if [[ -s /tmp/validation-summary.md ]]; then
+          echo "missing=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "missing=true" >> "$GITHUB_OUTPUT"
+        if [[ -n "$SESSION_ID" ]]; then
+          echo "::warning::The AI review ended without writing /tmp/validation-summary.md; resuming the session to retry once."
+        else
+          echo "::warning::No validation summary was written and there is no session to resume, so the AI review never started."
+        fi
+
+    - name: Retry the validation summary
+      id: components-retry
+      # A completed review that never wrote its report reaches the pull request as
+      # nothing at all, and the Summary step then fails the check. Resuming reuses
+      # the analysis the first attempt already paid for, so this costs one turn
+      # rather than a second full review. Skipped when there is no session to
+      # resume, which means the review never started.
+      #
+      # !cancelled() rather than always(): this still runs after an earlier step
+      # failed, but will not start a paid model session inside a cancelled run's
+      # shutdown window. cancel-in-progress is on in _validate-ai.yml, so that
+      # window is reached on every superseded push.
+      if: >-
+        !cancelled() &&
+        steps.summary-check.outputs.missing == 'true' &&
+        steps.components.outputs.session_id != ''
+      continue-on-error: true
+      uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
+      with:
+        anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-CODE-REVIEW-API-KEY }}
+        # Read and Write only. The analysis is already in the resumed session, so
+        # this needs no Bash, no subagents, and no plugins. Read is kept so the
+        # model can re-check a file while composing the report rather than
+        # deadlocking on a denied tool. max-turns bounds the cost: the point of
+        # resuming is to avoid paying for a second full review.
+        claude_args: |
+          --verbose
+          --model opus
+          --resume ${{ steps.components.outputs.session_id }}
+          --max-turns 5
+          --allowedTools "Read,Write"
+        prompt: |
+          Your previous turn ended without creating /tmp/validation-summary.md, so
+          the review you performed never reached the pull request.
+
+          Write that file now from the review already in this session. Use a single
+          Write call and do nothing else. Where a check did not apply or could not
+          run, say so in the report rather than leaving it out.
+
     - name: Ensure a validation summary exists
       id: ensure-summary
       if: always() && steps.changed-files.outputs.has_components == 'true' && steps.create-comment.outputs.comment_id != ''
@@ -347,17 +407,19 @@ runs:
         REPOSITORY: ${{ inputs.repository }}
         RUN_ID: ${{ github.run_id }}
         COMPONENTS_OUTCOME: ${{ steps.components.outcome }}
+        RETRY_OUTCOME: ${{ steps.components-retry.outcome }}
       run: |
-        # Claude writes the summary itself. If it errored or ended without one,
-        # write a fallback so the sticky comment reflects the failure instead of
-        # being left on the "reviewing..." placeholder, and flag it so the Summary
-        # step fails the check (a review that did not run must not pass green).
+        # Claude writes the summary itself, and the retry above gets a second
+        # attempt at it. If neither produced one, write a fallback so the sticky
+        # comment reflects the failure instead of being left on the "reviewing..."
+        # placeholder, and flag it so the Summary step fails the check (a review
+        # that did not run must not pass green).
         if [[ ! -s /tmp/validation-summary.md ]]; then
           echo "summary_missing=true" >> "$GITHUB_OUTPUT"
           {
             echo "### Claude Code validation did not complete"
             echo ""
-            echo "The AI review step finished without writing a summary (outcome: \`${COMPONENTS_OUTCOME:-unknown}\`). This usually means it errored or ran out of turns before producing its report."
+            echo "The AI review step finished without writing a summary (outcome: \`${COMPONENTS_OUTCOME:-unknown}\`, retry: \`${RETRY_OUTCOME:-not attempted}\`). This usually means it errored or ran out of turns before producing its report."
             echo ""
             echo "See the [Actions log](${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}) for details."
           } > /tmp/validation-summary.md
@@ -383,6 +445,7 @@ runs:
         MARKETPLACE_RESULT: ${{ steps.marketplace.outcome }}
         VERSION_BUMP_RESULT: ${{ steps.version-bump.outcome }}
         COMPONENTS_RESULT: ${{ steps.components.outcome }}
+        RETRY_RESULT: ${{ steps.components-retry.outcome }}
         SUMMARY_MISSING: ${{ steps.ensure-summary.outputs.summary_missing }}
         HAS_COMPONENTS: ${{ steps.changed-files.outputs.has_components }}
         CHANGED_PLUGINS: ${{ steps.changed-files.outputs.changed_plugins }}
@@ -403,6 +466,10 @@ runs:
         echo "Marketplace validation: ${MARKETPLACE_RESULT:-skipped}"
         echo "Version bump validation: ${VERSION_BUMP_RESULT:-skipped}"
         echo "Component & security validation (AI-driven): ${COMPONENTS_RESULT:-skipped}"
+        # Only printed when the summary was missing and a session existed to resume.
+        if [[ -n "$RETRY_RESULT" ]]; then
+          echo "Summary write retry (resumed session): ${RETRY_RESULT}"
+        fi
         echo ""
 
         if [[ -f /tmp/structure-validation.log ]] && [[ "$STRUCTURE_RESULT" == "failure" ]]; then

--- a/validate-ai/action.yml
+++ b/validate-ai/action.yml
@@ -240,9 +240,41 @@ runs:
 
           # RULES
 
-          1. The repository is already checked out at the PR head.
-          2. You can read files directly to inspect the changed Claude files.
-          3. Writing the report is mandatory and is the only way your results
+          1. The repository is checked out at the PR head, but the Claude
+             configuration in the working tree is NOT. See rule 2 before reading
+             any of it.
+          2. Read Claude configuration from `.claude-pr/`, not from the working
+             tree. Before this review begins, claude-code-action replaces these
+             repository-root paths with their base-branch versions, because
+             PR-authored config executes at CLI startup and so cannot be trusted:
+             `.claude/`, `CLAUDE.md`, `CLAUDE.local.md`, `.mcp.json`,
+             `.claude.json`, `.gitmodules`, `.ripgreprc`, and `.husky`. It first
+             snapshots the PR-authored versions to `.claude-pr/`, preserving the
+             original layout, specifically so a review agent can inspect them
+             safely. Only those root paths are affected; a nested path such as
+             `plugins/foo/.claude/` is left alone.
+
+             Map each changed path at one of those locations by prefixing it:
+             the PR's `.claude/CLAUDE.md` is at `.claude-pr/.claude/CLAUDE.md`,
+             and its root `CLAUDE.md` is at `.claude-pr/CLAUDE.md`. Quote line
+             numbers and text from the `.claude-pr/` copy, and report the path in
+             its original repo-relative form.
+
+             The working-tree copy of those paths is base-branch content. Never
+             quote it as this PR's work; doing so produces findings about code the
+             contributor did not write. A path present in the working tree with no
+             `.claude-pr/` counterpart was deleted by this PR.
+
+             Everything else is untouched and should be read from the working
+             tree as normal, including `plugins/`, `.claude-plugin/`, and
+             `scripts/`.
+
+             If a config file is listed as changed below and `.claude-pr/` does
+             not exist at all, stop treating the working tree as the PR's content
+             and say so in your report. That means this rule no longer matches
+             the action's behavior.
+          3. You can read files directly to inspect the changed Claude files.
+          4. Writing the report is mandatory and is the only way your results
              reach the pull request. When your review is complete, your final
              action must be to write the full report in markdown to
              /tmp/validation-summary.md. Do not post PR comments yourself, and do
@@ -307,7 +339,8 @@ runs:
           Claude file listed above (CLAUDE.md, and anything under `.claude/`:
           skills, agents, commands, hooks, and settings), use the
           reviewing-claude-config skill from the claude-config-validator plugin to
-          review structure and security:
+          review structure and security. These are exactly the paths rule 2
+          covers, so read them from `.claude-pr/`:
           - Scan for committed secrets (API keys, tokens, passwords)
           - Check for hardcoded credentials in code
           - Validate permission scoping in settings files


### PR DESCRIPTION
## 🎟️ Tracking

Follow-up to #863.

## 📔 Objective

Two fixes to `validate-ai`, both found while testing the org-wide rollout.

### 1. The AI step reviewed base-branch Claude configuration

bitwarden/ai-plugins#196 received a Major finding claiming `.claude/CLAUDE.md` still documented a workflow the repo no longer defines, quoting lines 62, 106, 108, 118, and 208. Those lines match `main`. None of the quoted text exists at the reviewed head.

The cause is in `claude-code-action`, not in our prompt. Before the review runs, [`restore-config.ts`](https://github.com/anthropics/claude-code-action/blob/be7b93b1907a4abad570368f3c74b6fe3807510b/src/github/operations/restore-config.ts) replaces these repository-root paths with their base-branch versions, because PR-authored Claude config executes at CLI startup before any tool-permission gating:

`.claude/`, `CLAUDE.md`, `CLAUDE.local.md`, `.mcp.json`, `.claude.json`, `.gitmodules`, `.ripgreprc`, `.husky`

The job log records it plainly: `Restoring .claude, .mcp.json, ... from origin/main (PR head is untrusted)`.

So the action was asking Claude to review precisely the files it had just reverted. The report's apparent self-contradiction, that the prose "is present as an uncommitted modification," was accurate reporting rather than a hallucination: `git checkout origin/main -- <path>` followed by `git reset` leaves exactly that.

`claude-code-action` already provides the answer. It snapshots the PR-authored versions to `.claude-pr/` before deleting them, preserving the original layout, "specifically so review agents can inspect what the PR changes without those files ever being executed." The prompt now directs the AI step to read those paths from `.claude-pr/`, quote line numbers from that copy, and report findings under the original repo-relative path. If the snapshot is ever absent, it must say so rather than silently review base-branch content.

No repository is special-cased. This affects any repo with root-level Claude config, which is every repo the org-wide workflow now covers.

### 2. A completed review that never wrote its report discarded the work

[Run 31525499670](https://github.com/bitwarden/ios/actions/runs/31525499670) in `bitwarden/ios` had the AI review report success after 27 turns and $1.50, then never write `/tmp/validation-summary.md`. The missing-summary guard failed the check, which is correct, but the finished analysis was thrown away and the pull request got a fallback comment instead of a review.

When the summary is missing, the action now resumes the same Claude session and asks for the report, costing about one turn rather than a second full review. `session_id` is an existing output of the pinned action version, documented for this use.

- `summary-check` exposes whether the file exists as a step output, because an `if:` on a `uses:` step cannot read the filesystem.
- `components-retry` resumes with `--allowedTools "Read,Write"` and `--max-turns 5`, and is skipped when there is no session to resume. Tool access is narrower than the first attempt, which grants `Task,Skill,Read,Write,Grep,Glob,Bash`.

Both use `!cancelled()` rather than `always()`, so a superseded push cannot start a paid model session during a cancelled run's shutdown.

The failure path is unchanged. A still-missing summary sets `summary_missing` and fails the check as before, and `Summary` still fails a genuinely failed review independently of the retry.

### Verification

`test-validate-ai.yml` triggers on `validate-ai/**`, so this PR exercises the happy path.

Neither fix is fully proven by CI, and both need a follow-up run to confirm:

- The config-source fix needs a run against a PR in `ai-plugins` that edits `.claude/CLAUDE.md`, confirming the posted report quotes head content rather than `main`.
- The retry needs a run where the summary is genuinely missing.

The pinned action's source was read to confirm both mechanisms: the `.claude-pr/` snapshot contract (including `test/restore-config.test.ts`), and that `resume` passes through `base-action/src/parse-sdk-options.ts` into `extraArgs` untouched with no conflicting `--session-id`.
