### PR TITLE
fix: stop validate-ai passing green on an unfinished AI review

### DIFF
--- a/.github/workflows/_validate-ai.yml
+++ b/.github/workflows/_validate-ai.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: check-permission
     if: needs.check-permission.outputs.should_proceed == 'true'
-    timeout-minutes: 20
+    timeout-minutes: 15
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/_validate-ai.yml
+++ b/.github/workflows/_validate-ai.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: check-permission
     if: needs.check-permission.outputs.should_proceed == 'true'
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions:
       actions: read
       contents: read

--- a/validate-ai/action.yml
+++ b/validate-ai/action.yml
@@ -433,6 +433,37 @@ runs:
           echo "::warning::The AI review ended without writing /tmp/validation-summary.md; retrying once."
         fi
 
+    - name: Preserve the PR config snapshot for the retry
+      id: preserve-snapshot
+      # claude-code-action rebuilds `.claude-pr/` on every invocation: it deletes
+      # the directory outright, then re-snapshots the root config paths from the
+      # working tree (restore-config.ts). The first invocation already replaced
+      # those working-tree paths with base-branch content, so a second invocation
+      # rebuilds the snapshot from the base branch — and for a path the PR added,
+      # the base checkout failed and left it deleted, so it is missing from the
+      # snapshot entirely. Either way the retry would read base-branch config
+      # while believing it was the PR's, find nothing, and pass the check on a
+      # review that never looked at the change.
+      #
+      # So take the first invocation's snapshot out of the way first. The action
+      # only ever touches `.claude-pr/`, so a copy under another name survives.
+      if: >-
+        !cancelled() &&
+        steps.summary-check.outputs.missing == 'true' &&
+        steps.create-comment.outputs.comment_id != ''
+      shell: bash
+      run: |
+        rm -rf .claude-pr-first-pass
+        if [[ -d .claude-pr ]]; then
+          cp -R .claude-pr .claude-pr-first-pass
+          echo "Preserved the first pass's .claude-pr/ snapshot as .claude-pr-first-pass/"
+          # Keep it out of git status for anything downstream that inspects the
+          # tree; the action does the same for .claude-pr/ itself.
+          echo "/.claude-pr-first-pass/" >> .git/info/exclude
+        else
+          echo "No .claude-pr/ snapshot exists; the retry will report that it could not read PR-authored root config."
+        fi
+
     - name: Retry the validation summary
       id: components-retry
       # A review that never wrote its report reaches the pull request as nothing
@@ -497,33 +528,43 @@ runs:
 
           # RULES
 
-          1. Read Claude configuration from `.claude-pr/`, not from the working
-             tree. claude-code-action replaced these repository-root paths with
-             their base-branch versions because PR-authored config executes at CLI
+          1. Read Claude configuration from `.claude-pr-first-pass/`. Do not read
+             it from the working tree, and do not read it from `.claude-pr/`.
+
+             claude-code-action replaced these repository-root paths with their
+             base-branch versions because PR-authored config executes at CLI
              startup and cannot be trusted: `.claude/`, `CLAUDE.md`,
              `CLAUDE.local.md`, `.mcp.json`, `.claude.json`, `.gitmodules`,
-             `.ripgreprc`, and `.husky`. The PR's versions were snapshotted to
+             `.ripgreprc`, and `.husky`. It snapshotted the PR's versions to
              `.claude-pr/` first, preserving the original layout. Only those root
              paths are affected; a nested path such as `plugins/foo/.claude/` is
              left alone.
 
-             Map each changed path at one of those locations by prefixing it: the
-             PR's `.claude/CLAUDE.md` is at `.claude-pr/.claude/CLAUDE.md`, and its
-             root `CLAUDE.md` is at `.claude-pr/CLAUDE.md`. Quote line numbers from
-             the `.claude-pr/` copy and report the path in its original
-             repo-relative form. Never quote the working-tree copy of those paths
-             as this PR's work — it is base-branch content, and findings against it
-             are findings about code the contributor did not write. A path present
-             in the working tree with no `.claude-pr/` counterpart was deleted by
-             this PR.
+             You are the second run of that action in this job, which is why you
+             read a different directory than the first attempt did. The action
+             rebuilds `.claude-pr/` from the working tree on every run, and by now
+             that tree holds base-branch content, so the `.claude-pr/` you can see
+             is base-branch content too. The first attempt's snapshot — the real
+             PR-authored config — was copied to `.claude-pr-first-pass/` before you
+             started.
+
+             Map each changed path by prefixing it: the PR's `.claude/CLAUDE.md` is
+             at `.claude-pr-first-pass/.claude/CLAUDE.md`, and its root `CLAUDE.md`
+             is at `.claude-pr-first-pass/CLAUDE.md`. Quote line numbers from that
+             copy and report the path in its original repo-relative form. Findings
+             quoted from the working tree or from `.claude-pr/` are findings about
+             base-branch code the contributor did not write.
 
              Everything else is untouched and reads from the working tree as
              normal, including `plugins/`, `.claude-plugin/`, and `scripts/`.
 
-             If a config file is listed as changed below and `.claude-pr/` does not
-             exist at all, stop treating the working tree as the PR's content and
-             say so in your report. That means this rule no longer matches the
-             action's behavior.
+             If a config file is listed as changed below and
+             `.claude-pr-first-pass/` does not exist, or the file has no
+             counterpart inside it, do not fall back to the working tree or to
+             `.claude-pr/`. Report that the PR-authored config could not be read
+             and that this section of the review did not run. Say so plainly: a
+             report that admits the gap is what lets a human catch it, and a clean
+             report that reviewed base-branch content hides it.
           2. Writing the report is mandatory and is the only way your results reach
              the pull request. Write it exactly once, as the last thing you do, and
              never write an interim or partial version. This session is
@@ -567,7 +608,7 @@ runs:
              claude-config-validator: committed secrets, hardcoded credentials,
              permission scoping in settings, dangerous command auto-approvals,
              overly broad file access, and malformed definitions. Read these from
-             `.claude-pr/` per rule 1.
+             `.claude-pr-first-pass/` per rule 1.
 
           ## Output Requirements
 

--- a/validate-ai/action.yml
+++ b/validate-ai/action.yml
@@ -222,9 +222,16 @@ runs:
         # that we cannot reliably enumerate; a tight allowlist would break the
         # review whenever that plugin changes. The write-permission gate in
         # _validate-ai.yml keeps this to trusted actors.
+        # max-turns bounds this attempt so it cannot consume the whole job
+        # timeout and leave the retry below no room to run. A composite step
+        # cannot carry its own timeout-minutes, so this is the only lever. The cap
+        # is generous — observed runs land in the 25-45 turn range — and hitting it
+        # ends the attempt without a report, which is exactly the state the retry
+        # exists to recover from.
         claude_args: |
           --verbose
           --model opus
+          --max-turns 80
           --allowedTools "Task,Skill,Read,Write,Grep,Glob,Bash"
         prompt: |
           REPO: ${{ inputs.repository }}
@@ -277,8 +284,21 @@ runs:
           4. Writing the report is mandatory and is the only way your results
              reach the pull request. When your review is complete, your final
              action must be to write the full report in markdown to
-             /tmp/validation-summary.md. Do not post PR comments yourself, and do
-             not end your turn until that file exists.
+             /tmp/validation-summary.md. Do not post PR comments yourself.
+
+             Write that file exactly once, as the last thing you do. Never write
+             an interim, partial, or "in progress" version of it. This session is
+             non-interactive: when your turn ends the process exits, so whatever
+             is in that file at that moment is what lands on the pull request,
+             permanently, with no chance to revise it.
+          5. Run every subagent synchronously — pass run_in_background: false
+             where that parameter exists — and wait for its result before moving
+             on. Subagents default to running in the background, on the
+             assumption that a notification will wake you when one finishes.
+             Nothing wakes you up here. If you end your turn while a subagent is
+             still running, it is killed and its findings are lost. Do not end
+             your turn while any subagent is outstanding, and do not report on
+             work a subagent has not yet returned.
 
           Changed files:
           ${{ steps.changed-files.outputs.changed_files }}
@@ -362,74 +382,214 @@ runs:
           checks pass, and even when every section above was skipped as not
           applicable. The sticky PR comment is replaced with its contents.
 
+          End the report with this line, exactly, on a line of its own:
+
+          <!-- validation-complete -->
+
+          That marker is how this action tells a finished report from an
+          abandoned one, so it must be the last line and it must only appear on
+          a report you consider complete. A report without it is discarded and
+          the check fails.
+
           # FINAL STEP (REQUIRED)
 
-          Your task is not done until /tmp/validation-summary.md exists on disk.
-          After the validations above, your final action must be a single Write
-          call that creates that file with the full report. If a section did not
-          apply or a check could not run, still write the file and say so. If you
-          have not written this file, you have not completed the task, no matter
-          what you reported in your responses.
+          Your task is not done until /tmp/validation-summary.md exists on disk
+          with the completion marker as its last line. After the validations
+          above, your final action must be a single Write call that creates that
+          file with the full report. If a section did not apply or a check could
+          not run, still write the file and say so — a report that documents a
+          skipped check is complete; one that omits it is not. If you have not
+          written this file, you have not completed the task, no matter what you
+          reported in your responses.
 
     - name: Check for a missing validation summary
       id: summary-check
       if: "!cancelled() && steps.changed-files.outputs.has_components == 'true'"
       shell: bash
-      env:
-        SESSION_ID: ${{ steps.components.outputs.session_id }}
       run: |
         # The retry below needs this as a step output, because an `if:` on a
         # `uses:` step cannot test the filesystem itself.
-        if [[ -s /tmp/validation-summary.md ]]; then
+        #
+        # Completeness is tested by the marker the prompt requires as the report's
+        # last line, not by the file merely existing. A review that ends mid-flight
+        # can leave a partial report behind — an "in progress" note, a report with
+        # sections still outstanding — and presence alone accepts that as the final
+        # word and posts it to the pull request under a green check.
+        if [[ -s /tmp/validation-summary.md ]] && grep -qF '<!-- validation-complete -->' /tmp/validation-summary.md; then
           echo "missing=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
 
         echo "missing=true" >> "$GITHUB_OUTPUT"
-        if [[ -n "$SESSION_ID" ]]; then
-          echo "::warning::The AI review ended without writing /tmp/validation-summary.md; resuming the session to retry once."
+        if [[ -s /tmp/validation-summary.md ]]; then
+          # Move it aside rather than leaving it in place: every step downstream
+          # treats the file's presence as a finished report, and the partial text
+          # must not reach the pull request. Keep a copy for the log.
+          mv /tmp/validation-summary.md /tmp/validation-summary.partial.md
+          echo "::warning::The AI review wrote an incomplete validation summary (no completion marker); discarding it and retrying once."
+          echo "Discarded partial summary:"
+          cat /tmp/validation-summary.partial.md
         else
-          echo "::warning::No validation summary was written and there is no session to resume, so the AI review never started."
+          echo "::warning::The AI review ended without writing /tmp/validation-summary.md; retrying once."
         fi
 
     - name: Retry the validation summary
       id: components-retry
-      # A completed review that never wrote its report reaches the pull request as
-      # nothing at all, and the Summary step then fails the check. Resuming reuses
-      # the analysis the first attempt already paid for, so this costs one turn
-      # rather than a second full review. Skipped when there is no session to
-      # resume, which means the review never started.
+      # A review that never wrote its report reaches the pull request as nothing
+      # at all, and the Summary step then fails the check. This second attempt is
+      # a fresh review, not a resumed session.
+      #
+      # An earlier version passed `--resume <session_id>` to reuse the first
+      # attempt's analysis for the price of one turn. It did not work:
+      # claude-code-action has no resume support and forwards `--resume` to the
+      # CLI as an opaque passthrough arg, and in practice the resumed run returned
+      # in 87ms having made no model call at all (`num_turns: 0`, `$0`), reporting
+      # success. The retry looked healthy in the log while doing nothing. The
+      # passthrough itself is sound in isolation, so the likeliest explanation is
+      # that a session abandoned mid-flight does not resume cleanly — which is
+      # exactly the state this step exists to recover from.
+      #
+      # So it pays for a second review instead. Bounded to keep that affordable:
+      # no Task (the first attempt's most likely failure was ending its turn on
+      # subagents it never awaited, and a fallback must not repeat it), no Bash,
+      # and a turn cap. The two plugins stay available for their skills, which run
+      # inline.
       #
       # !cancelled() rather than always(): this still runs after an earlier step
       # failed, but will not start a paid model session inside a cancelled run's
       # shutdown window. cancel-in-progress is on in _validate-ai.yml, so that
       # window is reached on every superseded push.
+      #
+      # comment_id gates on the setup ahead of the review having actually
+      # happened. summary-check runs under !cancelled(), so it also reports a
+      # missing summary when the review was never reached at all — an Azure login
+      # failure skips get-kv-secrets and create-comment, and without this gate the
+      # retry would fire with an empty API key, or pay for a full review with no
+      # comment to post it into. create-comment is the last of those steps, so its
+      # output is empty whenever any of them was skipped.
       if: >-
         !cancelled() &&
         steps.summary-check.outputs.missing == 'true' &&
-        steps.components.outputs.session_id != ''
+        steps.create-comment.outputs.comment_id != ''
       continue-on-error: true
       uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
       with:
         anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-CODE-REVIEW-API-KEY }}
-        # Read and Write only. The analysis is already in the resumed session, so
-        # this needs no Bash, no subagents, and no plugins. Read is kept so the
-        # model can re-check a file while composing the report rather than
-        # deadlocking on a denied tool. max-turns bounds the cost: the point of
-        # resuming is to avoid paying for a second full review.
+        plugin_marketplaces: |
+          https://github.com/anthropics/claude-code.git
+          https://github.com/bitwarden/ai-plugins.git
+        plugins: |
+          plugin-dev@claude-code-plugins
+          claude-config-validator@bitwarden-marketplace
         claude_args: |
           --verbose
           --model opus
-          --resume ${{ steps.components.outputs.session_id }}
-          --max-turns 5
-          --allowedTools "Read,Write"
+          --max-turns 30
+          --allowedTools "Skill,Read,Write,Grep,Glob"
         prompt: |
-          Your previous turn ended without creating /tmp/validation-summary.md, so
-          the review you performed never reached the pull request.
+          REPO: ${{ inputs.repository }}
+          PR NUMBER: ${{ inputs.pr_number }}
 
-          Write that file now from the review already in this session. Use a single
-          Write call and do nothing else. Where a check did not apply or could not
-          run, say so in the report rather than leaving it out.
+          A first attempt at this review ended without leaving a usable report, so
+          the pull request currently has no validation feedback on it. You are that
+          second attempt. Work alone, in this one context: you have no Task tool
+          and cannot dispatch subagents, so perform every check yourself.
+
+          # RULES
+
+          1. Read Claude configuration from `.claude-pr/`, not from the working
+             tree. claude-code-action replaced these repository-root paths with
+             their base-branch versions because PR-authored config executes at CLI
+             startup and cannot be trusted: `.claude/`, `CLAUDE.md`,
+             `CLAUDE.local.md`, `.mcp.json`, `.claude.json`, `.gitmodules`,
+             `.ripgreprc`, and `.husky`. The PR's versions were snapshotted to
+             `.claude-pr/` first, preserving the original layout. Only those root
+             paths are affected; a nested path such as `plugins/foo/.claude/` is
+             left alone.
+
+             Map each changed path at one of those locations by prefixing it: the
+             PR's `.claude/CLAUDE.md` is at `.claude-pr/.claude/CLAUDE.md`, and its
+             root `CLAUDE.md` is at `.claude-pr/CLAUDE.md`. Quote line numbers from
+             the `.claude-pr/` copy and report the path in its original
+             repo-relative form. Never quote the working-tree copy of those paths
+             as this PR's work — it is base-branch content, and findings against it
+             are findings about code the contributor did not write. A path present
+             in the working tree with no `.claude-pr/` counterpart was deleted by
+             this PR.
+
+             Everything else is untouched and reads from the working tree as
+             normal, including `plugins/`, `.claude-plugin/`, and `scripts/`.
+
+             If a config file is listed as changed below and `.claude-pr/` does not
+             exist at all, stop treating the working tree as the PR's content and
+             say so in your report. That means this rule no longer matches the
+             action's behavior.
+          2. Writing the report is mandatory and is the only way your results reach
+             the pull request. Write it exactly once, as the last thing you do, and
+             never write an interim or partial version. This session is
+             non-interactive: when your turn ends the process exits, and whatever
+             is in that file at that moment lands on the pull request permanently.
+
+          Changed files:
+          ${{ steps.changed-files.outputs.changed_files }}
+
+          Changed plugins:
+          ${{ steps.changed-files.outputs.changed_plugins }}
+
+          Agent files changed:
+          ${{ steps.changed-files.outputs.agent_files }}
+
+          Skill files changed:
+          ${{ steps.changed-files.outputs.skill_files }}
+
+          Command files changed:
+          ${{ steps.changed-files.outputs.command_files }}
+
+          Hook files changed:
+          ${{ steps.changed-files.outputs.hook_files }}
+
+          Config files changed (CLAUDE.md, .claude/):
+          ${{ steps.changed-files.outputs.config_files }}
+
+          Cover these three areas, skipping any that has no changed files above:
+
+          1. Plugin structure for each changed plugin — plugin.json manifest
+             correctness, directory layout and auto-discovery, command and agent
+             frontmatter, hooks JSON schema and ${CLAUDE_PLUGIN_ROOT} usage in
+             script paths, MCP server configuration, README presence, and hardcoded
+             credentials. The plugin-dev plugin's skills describe these rules; read
+             them rather than working from memory.
+          2. Each changed SKILL.md — frontmatter, description quality and trigger
+             phrases, content length, progressive disclosure, and whether every
+             referenced file exists.
+          3. Configuration and security for `CLAUDE.md` and anything under
+             `.claude/`, using the reviewing-claude-config skill from
+             claude-config-validator: committed secrets, hardcoded credentials,
+             permission scoping in settings, dangerous command auto-approvals,
+             overly broad file access, and malformed definitions. Read these from
+             `.claude-pr/` per rule 1.
+
+          ## Output Requirements
+
+          Write your report to /tmp/validation-summary.md as a single structured
+          markdown document:
+          - Categorize issues by severity: critical, major, minor
+          - Include the exact file path and line for each issue
+          - Provide specific remediation guidance for each violation
+          - Distinguish errors (must fix) from warnings (should fix)
+          - If all checks pass, confirm with a summary of what was validated
+          - Note that this report came from a second attempt after the first review
+            failed to produce one
+
+          End the report with this line, exactly, on a line of its own:
+
+          <!-- validation-complete -->
+
+          A report without that marker as its last line is discarded and the check
+          fails, so write it only on a report you consider complete. If a section
+          did not apply or a check could not run, say so in the report and keep the
+          marker — a report that documents a skipped check is complete; one that
+          omits it is not.
 
     - name: Ensure a validation summary exists
       id: ensure-summary
@@ -443,20 +603,39 @@ runs:
         RETRY_OUTCOME: ${{ steps.components-retry.outcome }}
       run: |
         # Claude writes the summary itself, and the retry above gets a second
-        # attempt at it. If neither produced one, write a fallback so the sticky
-        # comment reflects the failure instead of being left on the "reviewing..."
-        # placeholder, and flag it so the Summary step fails the check (a review
-        # that did not run must not pass green).
-        if [[ ! -s /tmp/validation-summary.md ]]; then
-          echo "summary_missing=true" >> "$GITHUB_OUTPUT"
-          {
-            echo "### Claude Code validation did not complete"
-            echo ""
-            echo "The AI review step finished without writing a summary (outcome: \`${COMPONENTS_OUTCOME:-unknown}\`, retry: \`${RETRY_OUTCOME:-not attempted}\`). This usually means it errored or ran out of turns before producing its report."
-            echo ""
-            echo "See the [Actions log](${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}) for details."
-          } > /tmp/validation-summary.md
+        # attempt at it. Both are tested for the completion marker, not just for
+        # the file existing: the retry can end mid-flight the same way the first
+        # attempt did, and a partial report must not reach the pull request merely
+        # because something is on disk. If neither attempt produced a complete
+        # report, write a fallback so the sticky comment reflects the failure
+        # instead of being left on the "reviewing..." placeholder, and flag it so
+        # the Summary step fails the check (a review that did not run must not
+        # pass green).
+        if [[ -s /tmp/validation-summary.md ]] && grep -qF '<!-- validation-complete -->' /tmp/validation-summary.md; then
+          exit 0
         fi
+
+        echo "summary_missing=true" >> "$GITHUB_OUTPUT"
+        if [[ -s /tmp/validation-summary.md ]]; then
+          mv /tmp/validation-summary.md /tmp/validation-summary.partial.md
+          echo "::warning::The retry also produced an incomplete validation summary; discarding it."
+          echo "Discarded partial summary:"
+          cat /tmp/validation-summary.partial.md
+        fi
+
+        {
+          echo "### Claude Code validation did not complete"
+          echo ""
+          echo "Neither the AI review nor its retry produced a complete report, so this check has no validation feedback to show."
+          echo ""
+          echo "Step outcomes: review \`${COMPONENTS_OUTCOME:-unknown}\`, retry \`${RETRY_OUTCOME:-not attempted}\`. A step can report success and still end without a finished report, so these outcomes do not mean the review ran."
+          if [[ -s /tmp/validation-summary.partial.md ]]; then
+            echo ""
+            echo "A partial report was written and discarded; the Actions log quotes it in full."
+          fi
+          echo ""
+          echo "See the [Actions log](${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}) for details."
+        } > /tmp/validation-summary.md
 
     - name: Update PR comment with validation summary
       if: always() && steps.changed-files.outputs.has_components == 'true' && steps.create-comment.outputs.comment_id != ''
@@ -499,9 +678,16 @@ runs:
         echo "Marketplace validation: ${MARKETPLACE_RESULT:-skipped}"
         echo "Version bump validation: ${VERSION_BUMP_RESULT:-skipped}"
         echo "Component & security validation (AI-driven): ${COMPONENTS_RESULT:-skipped}"
-        # Only printed when the summary was missing and a session existed to resume.
+        # Only printed when the first attempt left no complete report. Report
+        # whether the retry produced one rather than whether the step exited 0 —
+        # the step can succeed having done nothing, and printing that bare
+        # "success" reads as though the retry worked.
         if [[ -n "$RETRY_RESULT" ]]; then
-          echo "Summary write retry (resumed session): ${RETRY_RESULT}"
+          if [[ "$SUMMARY_MISSING" == "true" ]]; then
+            echo "Second review attempt: ${RETRY_RESULT}, but produced no complete report"
+          else
+            echo "Second review attempt: ${RETRY_RESULT}, report recovered"
+          fi
         fi
         echo ""
 
@@ -539,11 +725,12 @@ runs:
           echo ""
         fi
 
-        # The AI step can exit 0 without producing a report (e.g. permission
-        # denials or an early exit). Treat a missing summary as a failure so the
-        # check never goes green on a review that did not actually run.
+        # The AI step can exit 0 having produced no report, or a partial one it
+        # never got to finish (e.g. permission denials, an early exit, or a turn
+        # that ended on work still in flight). Treat either as a failure so the
+        # check never goes green on a review that did not actually finish.
         if [[ "$SUMMARY_MISSING" == "true" ]]; then
-          echo "AI-driven review produced no summary; a fallback was posted to the PR comment."
+          echo "AI-driven review produced no complete summary; a fallback was posted to the PR comment."
           echo ""
         fi
 

--- a/validate-ai/action.yml
+++ b/validate-ai/action.yml
@@ -222,12 +222,13 @@ runs:
         # that we cannot reliably enumerate; a tight allowlist would break the
         # review whenever that plugin changes. The write-permission gate in
         # _validate-ai.yml keeps this to trusted actors.
-        # max-turns bounds this attempt so it cannot consume the whole job
-        # timeout and leave the retry below no room to run. A composite step
-        # cannot carry its own timeout-minutes, so this is the only lever. The cap
-        # is generous — observed runs land in the 25-45 turn range — and hitting it
-        # ends the attempt without a report, which is exactly the state the retry
-        # exists to recover from.
+        # max-turns turns a runaway review into a graceful failure. A composite
+        # step cannot carry its own timeout-minutes, so without a cap the job
+        # timeout is the only bound, and a timeout kill skips the steps that post
+        # the sticky comment: the pull request would be left on the "reviewing..."
+        # placeholder with no explanation. Hitting the cap instead ends the step,
+        # posts the fallback comment, and fails the check. The cap is generous;
+        # observed runs land in the 25-45 turn range.
         claude_args: |
           --verbose
           --model opus
@@ -402,236 +403,6 @@ runs:
           written this file, you have not completed the task, no matter what you
           reported in your responses.
 
-    - name: Check for a missing validation summary
-      id: summary-check
-      if: "!cancelled() && steps.changed-files.outputs.has_components == 'true'"
-      shell: bash
-      run: |
-        # The retry below needs this as a step output, because an `if:` on a
-        # `uses:` step cannot test the filesystem itself.
-        #
-        # Completeness is tested by the marker the prompt requires as the report's
-        # last line, not by the file merely existing. A review that ends mid-flight
-        # can leave a partial report behind — an "in progress" note, a report with
-        # sections still outstanding — and presence alone accepts that as the final
-        # word and posts it to the pull request under a green check.
-        if [[ -s /tmp/validation-summary.md ]] && grep -qF '<!-- validation-complete -->' /tmp/validation-summary.md; then
-          echo "missing=false" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        echo "missing=true" >> "$GITHUB_OUTPUT"
-        if [[ -s /tmp/validation-summary.md ]]; then
-          # Move it aside rather than leaving it in place: every step downstream
-          # treats the file's presence as a finished report, and the partial text
-          # must not reach the pull request. Keep a copy for the log.
-          mv /tmp/validation-summary.md /tmp/validation-summary.partial.md
-          echo "::warning::The AI review wrote an incomplete validation summary (no completion marker); discarding it and retrying once."
-          echo "Discarded partial summary:"
-          cat /tmp/validation-summary.partial.md
-        else
-          echo "::warning::The AI review ended without writing /tmp/validation-summary.md; retrying once."
-        fi
-
-    - name: Preserve the PR config snapshot for the retry
-      id: preserve-snapshot
-      # claude-code-action rebuilds `.claude-pr/` on every invocation: it deletes
-      # the directory outright, then re-snapshots the root config paths from the
-      # working tree (restore-config.ts). The first invocation already replaced
-      # those working-tree paths with base-branch content, so a second invocation
-      # rebuilds the snapshot from the base branch — and for a path the PR added,
-      # the base checkout failed and left it deleted, so it is missing from the
-      # snapshot entirely. Either way the retry would read base-branch config
-      # while believing it was the PR's, find nothing, and pass the check on a
-      # review that never looked at the change.
-      #
-      # So take the first invocation's snapshot out of the way first. The action
-      # only ever touches `.claude-pr/`, so a copy under another name survives.
-      if: >-
-        !cancelled() &&
-        steps.summary-check.outputs.missing == 'true' &&
-        steps.create-comment.outputs.comment_id != ''
-      shell: bash
-      run: |
-        rm -rf .claude-pr-first-pass
-        if [[ -d .claude-pr ]]; then
-          cp -R .claude-pr .claude-pr-first-pass
-          echo "Preserved the first pass's .claude-pr/ snapshot as .claude-pr-first-pass/"
-          # Keep it out of git status for anything downstream that inspects the
-          # tree; the action does the same for .claude-pr/ itself.
-          echo "/.claude-pr-first-pass/" >> .git/info/exclude
-        else
-          echo "No .claude-pr/ snapshot exists; the retry will report that it could not read PR-authored root config."
-        fi
-
-    - name: Retry the validation summary
-      id: components-retry
-      # A review that never wrote its report reaches the pull request as nothing
-      # at all, and the Summary step then fails the check. This second attempt is
-      # a fresh review, not a resumed session.
-      #
-      # An earlier version passed `--resume <session_id>` to reuse the first
-      # attempt's analysis for the price of one turn. It did not work:
-      # claude-code-action has no resume support and forwards `--resume` to the
-      # CLI as an opaque passthrough arg, and in practice the resumed run returned
-      # in 87ms having made no model call at all (`num_turns: 0`, `$0`), reporting
-      # success. The retry looked healthy in the log while doing nothing. The
-      # passthrough itself is sound in isolation, so the likeliest explanation is
-      # that a session abandoned mid-flight does not resume cleanly — which is
-      # exactly the state this step exists to recover from.
-      #
-      # So it pays for a second review instead. Bounded to keep that affordable:
-      # no Task (the first attempt's most likely failure was ending its turn on
-      # subagents it never awaited, and a fallback must not repeat it), no Bash,
-      # and a turn cap. The two plugins stay available for their skills, which run
-      # inline.
-      #
-      # !cancelled() rather than always(): this still runs after an earlier step
-      # failed, but will not start a paid model session inside a cancelled run's
-      # shutdown window. cancel-in-progress is on in _validate-ai.yml, so that
-      # window is reached on every superseded push.
-      #
-      # comment_id gates on the setup ahead of the review having actually
-      # happened. summary-check runs under !cancelled(), so it also reports a
-      # missing summary when the review was never reached at all — an Azure login
-      # failure skips get-kv-secrets and create-comment, and without this gate the
-      # retry would fire with an empty API key, or pay for a full review with no
-      # comment to post it into. create-comment is the last of those steps, so its
-      # output is empty whenever any of them was skipped.
-      if: >-
-        !cancelled() &&
-        steps.summary-check.outputs.missing == 'true' &&
-        steps.create-comment.outputs.comment_id != ''
-      continue-on-error: true
-      uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
-      with:
-        anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-CODE-REVIEW-API-KEY }}
-        plugin_marketplaces: |
-          https://github.com/anthropics/claude-code.git
-          https://github.com/bitwarden/ai-plugins.git
-        plugins: |
-          plugin-dev@claude-code-plugins
-          claude-config-validator@bitwarden-marketplace
-        claude_args: |
-          --verbose
-          --model opus
-          --max-turns 30
-          --allowedTools "Skill,Read,Write,Grep,Glob"
-        prompt: |
-          REPO: ${{ inputs.repository }}
-          PR NUMBER: ${{ inputs.pr_number }}
-
-          A first attempt at this review ended without leaving a usable report, so
-          the pull request currently has no validation feedback on it. You are that
-          second attempt. Work alone, in this one context: you have no Task tool
-          and cannot dispatch subagents, so perform every check yourself.
-
-          # RULES
-
-          1. Read Claude configuration from `.claude-pr-first-pass/`. Do not read
-             it from the working tree, and do not read it from `.claude-pr/`.
-
-             claude-code-action replaced these repository-root paths with their
-             base-branch versions because PR-authored config executes at CLI
-             startup and cannot be trusted: `.claude/`, `CLAUDE.md`,
-             `CLAUDE.local.md`, `.mcp.json`, `.claude.json`, `.gitmodules`,
-             `.ripgreprc`, and `.husky`. It snapshotted the PR's versions to
-             `.claude-pr/` first, preserving the original layout. Only those root
-             paths are affected; a nested path such as `plugins/foo/.claude/` is
-             left alone.
-
-             You are the second run of that action in this job, which is why you
-             read a different directory than the first attempt did. The action
-             rebuilds `.claude-pr/` from the working tree on every run, and by now
-             that tree holds base-branch content, so the `.claude-pr/` you can see
-             is base-branch content too. The first attempt's snapshot — the real
-             PR-authored config — was copied to `.claude-pr-first-pass/` before you
-             started.
-
-             Map each changed path by prefixing it: the PR's `.claude/CLAUDE.md` is
-             at `.claude-pr-first-pass/.claude/CLAUDE.md`, and its root `CLAUDE.md`
-             is at `.claude-pr-first-pass/CLAUDE.md`. Quote line numbers from that
-             copy and report the path in its original repo-relative form. Findings
-             quoted from the working tree or from `.claude-pr/` are findings about
-             base-branch code the contributor did not write.
-
-             Everything else is untouched and reads from the working tree as
-             normal, including `plugins/`, `.claude-plugin/`, and `scripts/`.
-
-             If a config file is listed as changed below and
-             `.claude-pr-first-pass/` does not exist, or the file has no
-             counterpart inside it, do not fall back to the working tree or to
-             `.claude-pr/`. Report that the PR-authored config could not be read
-             and that this section of the review did not run. Say so plainly: a
-             report that admits the gap is what lets a human catch it, and a clean
-             report that reviewed base-branch content hides it.
-          2. Writing the report is mandatory and is the only way your results reach
-             the pull request. Write it exactly once, as the last thing you do, and
-             never write an interim or partial version. This session is
-             non-interactive: when your turn ends the process exits, and whatever
-             is in that file at that moment lands on the pull request permanently.
-
-          Changed files:
-          ${{ steps.changed-files.outputs.changed_files }}
-
-          Changed plugins:
-          ${{ steps.changed-files.outputs.changed_plugins }}
-
-          Agent files changed:
-          ${{ steps.changed-files.outputs.agent_files }}
-
-          Skill files changed:
-          ${{ steps.changed-files.outputs.skill_files }}
-
-          Command files changed:
-          ${{ steps.changed-files.outputs.command_files }}
-
-          Hook files changed:
-          ${{ steps.changed-files.outputs.hook_files }}
-
-          Config files changed (CLAUDE.md, .claude/):
-          ${{ steps.changed-files.outputs.config_files }}
-
-          Cover these three areas, skipping any that has no changed files above:
-
-          1. Plugin structure for each changed plugin — plugin.json manifest
-             correctness, directory layout and auto-discovery, command and agent
-             frontmatter, hooks JSON schema and ${CLAUDE_PLUGIN_ROOT} usage in
-             script paths, MCP server configuration, README presence, and hardcoded
-             credentials. The plugin-dev plugin's skills describe these rules; read
-             them rather than working from memory.
-          2. Each changed SKILL.md — frontmatter, description quality and trigger
-             phrases, content length, progressive disclosure, and whether every
-             referenced file exists.
-          3. Configuration and security for `CLAUDE.md` and anything under
-             `.claude/`, using the reviewing-claude-config skill from
-             claude-config-validator: committed secrets, hardcoded credentials,
-             permission scoping in settings, dangerous command auto-approvals,
-             overly broad file access, and malformed definitions. Read these from
-             `.claude-pr-first-pass/` per rule 1.
-
-          ## Output Requirements
-
-          Write your report to /tmp/validation-summary.md as a single structured
-          markdown document:
-          - Categorize issues by severity: critical, major, minor
-          - Include the exact file path and line for each issue
-          - Provide specific remediation guidance for each violation
-          - Distinguish errors (must fix) from warnings (should fix)
-          - If all checks pass, confirm with a summary of what was validated
-          - Note that this report came from a second attempt after the first review
-            failed to produce one
-
-          End the report with this line, exactly, on a line of its own:
-
-          <!-- validation-complete -->
-
-          A report without that marker as its last line is discarded and the check
-          fails, so write it only on a report you consider complete. If a section
-          did not apply or a check could not run, say so in the report and keep the
-          marker — a report that documents a skipped check is complete; one that
-          omits it is not.
-
     - name: Ensure a validation summary exists
       id: ensure-summary
       if: always() && steps.changed-files.outputs.has_components == 'true' && steps.create-comment.outputs.comment_id != ''
@@ -641,35 +412,41 @@ runs:
         REPOSITORY: ${{ inputs.repository }}
         RUN_ID: ${{ github.run_id }}
         COMPONENTS_OUTCOME: ${{ steps.components.outcome }}
-        RETRY_OUTCOME: ${{ steps.components-retry.outcome }}
       run: |
-        # Claude writes the summary itself, and the retry above gets a second
-        # attempt at it. Both are tested for the completion marker, not just for
-        # the file existing: the retry can end mid-flight the same way the first
-        # attempt did, and a partial report must not reach the pull request merely
-        # because something is on disk. If neither attempt produced a complete
-        # report, write a fallback so the sticky comment reflects the failure
-        # instead of being left on the "reviewing..." placeholder, and flag it so
-        # the Summary step fails the check (a review that did not run must not
-        # pass green).
+        # Claude writes the summary itself. Completeness is decided by the marker
+        # the prompt requires as the report's last line, not by the file existing:
+        # a review that ends mid-flight can leave a partial report behind, and
+        # presence alone accepts that as the final word and posts it to the pull
+        # request under a green check.
+        #
+        # Anything short of a marked report gets a fallback instead, so the sticky
+        # comment reflects the failure rather than being left on the "reviewing..."
+        # placeholder, and summary_missing fails the check (a review that did not
+        # finish must not pass green). Recovery is a re-run of the job, which
+        # starts a clean review.
         if [[ -s /tmp/validation-summary.md ]] && grep -qF '<!-- validation-complete -->' /tmp/validation-summary.md; then
           exit 0
         fi
 
         echo "summary_missing=true" >> "$GITHUB_OUTPUT"
         if [[ -s /tmp/validation-summary.md ]]; then
+          # Move it aside rather than leaving it in place: the step below posts
+          # whatever is at this path, and the partial text must not reach the pull
+          # request. Keep a copy for the log.
           mv /tmp/validation-summary.md /tmp/validation-summary.partial.md
-          echo "::warning::The retry also produced an incomplete validation summary; discarding it."
+          echo "::warning::The AI review wrote an incomplete validation summary (no completion marker); discarding it."
           echo "Discarded partial summary:"
           cat /tmp/validation-summary.partial.md
+        else
+          echo "::warning::The AI review ended without writing /tmp/validation-summary.md."
         fi
 
         {
           echo "### Claude Code validation did not complete"
           echo ""
-          echo "Neither the AI review nor its retry produced a complete report, so this check has no validation feedback to show."
+          echo "The AI review did not produce a complete report, so this check has no validation feedback to show. Re-running the job starts a fresh review."
           echo ""
-          echo "Step outcomes: review \`${COMPONENTS_OUTCOME:-unknown}\`, retry \`${RETRY_OUTCOME:-not attempted}\`. A step can report success and still end without a finished report, so these outcomes do not mean the review ran."
+          echo "Review step outcome: \`${COMPONENTS_OUTCOME:-unknown}\`. A step can report success and still end without a finished report, so that outcome does not mean the review ran."
           if [[ -s /tmp/validation-summary.partial.md ]]; then
             echo ""
             echo "A partial report was written and discarded; the Actions log quotes it in full."
@@ -698,7 +475,6 @@ runs:
         MARKETPLACE_RESULT: ${{ steps.marketplace.outcome }}
         VERSION_BUMP_RESULT: ${{ steps.version-bump.outcome }}
         COMPONENTS_RESULT: ${{ steps.components.outcome }}
-        RETRY_RESULT: ${{ steps.components-retry.outcome }}
         SUMMARY_MISSING: ${{ steps.ensure-summary.outputs.summary_missing }}
         HAS_COMPONENTS: ${{ steps.changed-files.outputs.has_components }}
         CHANGED_PLUGINS: ${{ steps.changed-files.outputs.changed_plugins }}
@@ -718,17 +494,13 @@ runs:
         echo "Plugin structure validation: ${STRUCTURE_RESULT:-skipped}"
         echo "Marketplace validation: ${MARKETPLACE_RESULT:-skipped}"
         echo "Version bump validation: ${VERSION_BUMP_RESULT:-skipped}"
-        echo "Component & security validation (AI-driven): ${COMPONENTS_RESULT:-skipped}"
-        # Only printed when the first attempt left no complete report. Report
-        # whether the retry produced one rather than whether the step exited 0 —
-        # the step can succeed having done nothing, and printing that bare
-        # "success" reads as though the retry worked.
-        if [[ -n "$RETRY_RESULT" ]]; then
-          if [[ "$SUMMARY_MISSING" == "true" ]]; then
-            echo "Second review attempt: ${RETRY_RESULT}, but produced no complete report"
-          else
-            echo "Second review attempt: ${RETRY_RESULT}, report recovered"
-          fi
+        # Report whether a complete report was produced rather than only the step's
+        # exit status: the step can succeed and still end without one, and a bare
+        # "success" on that line reads as though the review landed.
+        if [[ "$SUMMARY_MISSING" == "true" ]]; then
+          echo "Component & security validation (AI-driven): ${COMPONENTS_RESULT:-skipped}, but produced no complete report"
+        else
+          echo "Component & security validation (AI-driven): ${COMPONENTS_RESULT:-skipped}"
         fi
         echo ""
 
@@ -771,7 +543,7 @@ runs:
         # that ended on work still in flight). Treat either as a failure so the
         # check never goes green on a review that did not actually finish.
         if [[ "$SUMMARY_MISSING" == "true" ]]; then
-          echo "AI-driven review produced no complete summary; a fallback was posted to the PR comment."
+          echo "AI-driven review produced no complete summary; a fallback was posted to the PR comment. Re-run the job to start a fresh review."
           echo ""
         fi
 


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/ai-plugins/pull/197

## 📔 Objective

`validate-ai` gated its check on `[[ -s /tmp/validation-summary.md ]]`, which cannot tell a finished report from an abandoned one.

Two runs on the tracking PR showed both halves of the problem. [Run 31637041506](https://github.com/bitwarden/ai-plugins/actions/runs/31637041506) ended its turn having written only "In progress — plugin-validator and skill-reviewer agents still running", and that text was posted as the review under a green check. [Run 31638957329](https://github.com/bitwarden/ai-plugins/actions/runs/31638957329) wrote nothing and failed correctly, but its `--resume` recovery step returned in 87ms with `num_turns: 0`, having made no model call while reporting success.

Both trace to the same thing: subagents default to background execution, expecting a notification to wake the parent when one finishes. Nothing wakes it in a headless run, so ending the turn kills whatever is still in flight.

### Changes

- The report must end with `<!-- validation-complete -->`, and `ensure-summary` tests for that marker instead of for the file existing. A partial report is quarantined, quoted into the log, and never posted.
- The prompt forbids interim writes and requires subagents run synchronously.
- The first pass is capped at `--max-turns 80`. A runaway now posts the fallback comment rather than hitting the job timeout, which would skip the comment update and leave the placeholder in place.
- The retry is gone, and so is `summary-check`, whose only consumer was the retry's condition. Every review finding on this PR was a defect in the retry, and it bought little over the fallback: a run that leaves no report already posts a comment saying so and fails the check, and re-running the job starts a clean review. That leaves 13 steps, two fewer than before this branch.

Verification: the guard body was extracted from the parsed YAML and run under `bash -e -o pipefail` against a complete report, a partial report using run 31637041506's actual text, and no file at all. This has not run against a live PR yet.

## 🚨 Breaking Changes

No interface change, and nothing for consumers to migrate.

One behavior change is worth flagging, since `org-validate-ai.yml` runs on every PR in every org repo. A PR whose review ends without a finished report now fails the check, where a partial report previously passed green with the partial text posted as the review. Repos that were quietly getting truncated reviews will start seeing red checks. That is the point, but it will look like a new failure to whoever hits it first.
