### PR TITLE
fix: give the AI review time to finish and let its subagents overlap

### DIFF
--- a/.github/workflows/_validate-ai.yml
+++ b/.github/workflows/_validate-ai.yml
@@ -31,7 +31,14 @@ jobs:
     runs-on: ubuntu-24.04
     needs: check-permission
     if: needs.check-permission.outputs.should_proceed == 'true'
-    timeout-minutes: 15
+    # A review that actually waits for its subagents takes far longer than the
+    # abandoned reviews this budget was originally sized against: run 31699838478
+    # in bitwarden/ai-plugins spent over 14 minutes on the same input that earlier
+    # runs "finished" in four, and was killed here at 15. The step cannot carry a
+    # timeout of its own, and the model's turn cap does not bound wall clock, so
+    # this is the only limit that does. Set generously until a run completes and
+    # gives a real duration to tune against.
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/_validate-ai.yml
+++ b/.github/workflows/_validate-ai.yml
@@ -31,13 +31,6 @@ jobs:
     runs-on: ubuntu-24.04
     needs: check-permission
     if: needs.check-permission.outputs.should_proceed == 'true'
-    # A review that actually waits for its subagents takes far longer than the
-    # abandoned reviews this budget was originally sized against: run 31699838478
-    # in bitwarden/ai-plugins spent over 14 minutes on the same input that earlier
-    # runs "finished" in four, and was killed here at 15. The step cannot carry a
-    # timeout of its own, and the model's turn cap does not bound wall clock, so
-    # this is the only limit that does. Set generously until a run completes and
-    # gives a real duration to tune against.
     timeout-minutes: 30
     permissions:
       actions: read

--- a/validate-ai/action.yml
+++ b/validate-ai/action.yml
@@ -222,13 +222,19 @@ runs:
         # that we cannot reliably enumerate; a tight allowlist would break the
         # review whenever that plugin changes. The write-permission gate in
         # _validate-ai.yml keeps this to trusted actors.
-        # max-turns turns a runaway review into a graceful failure. A composite
-        # step cannot carry its own timeout-minutes, so without a cap the job
-        # timeout is the only bound, and a timeout kill skips the steps that post
-        # the sticky comment: the pull request would be left on the "reviewing..."
-        # placeholder with no explanation. Hitting the cap instead ends the step,
-        # posts the fallback comment, and fails the check. The cap is generous;
-        # observed runs land in the 25-45 turn range.
+        # max-turns bounds turn count, not wall clock, and the two are only loosely
+        # related here: a single Task turn is an entire subagent run, so a review
+        # can spend a quarter of an hour inside a couple of dozen turns. Run
+        # 31699838478 in bitwarden/ai-plugins hit the 15-minute job timeout without
+        # coming near this cap. Treat it as a backstop against a loop, not as the
+        # thing that keeps a review inside its time budget; the job timeout in
+        # _validate-ai.yml is what does that, and a composite step cannot carry a
+        # timeout of its own. Observed runs land in the 25-45 turn range.
+        #
+        # A timeout kill is survivable either way: the steps that post the sticky
+        # comment run under always(), and GitHub still executes them in the
+        # cancellation window, so the pull request gets the fallback rather than
+        # being left on the "reviewing..." placeholder.
         claude_args: |
           --verbose
           --model opus
@@ -293,13 +299,23 @@ runs:
              is in that file at that moment is what lands on the pull request,
              permanently, with no chance to revise it.
           5. Run every subagent synchronously — pass run_in_background: false
-             where that parameter exists — and wait for its result before moving
-             on. Subagents default to running in the background, on the
-             assumption that a notification will wake you when one finishes.
-             Nothing wakes you up here. If you end your turn while a subagent is
-             still running, it is killed and its findings are lost. Do not end
-             your turn while any subagent is outstanding, and do not report on
-             work a subagent has not yet returned.
+             where that parameter exists. Subagents default to running in the
+             background, on the assumption that a notification will wake you when
+             one finishes. Nothing wakes you up here. If you end your turn while a
+             subagent is still running, it is killed and its findings are lost. Do
+             not end your turn while any subagent is outstanding, and do not report
+             on work a subagent has not yet returned.
+
+             Synchronous does not mean one at a time. This review is on a wall
+             clock, so dispatch independent subagents together in a single message
+             with several tool calls: they then run concurrently and all return
+             before your turn ends, which is both faster and safe.
+
+             Every subagent call in sections 1 and 2 below is independent of every
+             other one, and there can be more than two of them: section 1 is one
+             validation per changed plugin and section 2 is one review per changed
+             skill. Work out the full set first and send all of it in one message,
+             rather than batching by section or dispatching one at a time.
 
           Changed files:
           ${{ steps.changed-files.outputs.changed_files }}
@@ -322,7 +338,12 @@ runs:
           Config files changed (CLAUDE.md, .claude/):
           ${{ steps.changed-files.outputs.config_files }}
 
-          Perform the following validations in order:
+          Perform the following validations. Sections 1 and 2 are subagent work and
+          every call in them is independent, so send them all out in one message per
+          rule 5 rather than waiting for one to finish before dispatching the next.
+          Section 3 is yours to carry out once their results come back. The numbering
+          is for reference and for the order of the report, not an order of
+          execution.
 
           ## 1. Plugin Validation (plugin-validator agent from plugin-dev)
 

--- a/validate-ai/action.yml
+++ b/validate-ai/action.yml
@@ -45,8 +45,7 @@ runs:
         git fetch origin "$BASE_REF"
         CHANGED_FILES=$(git diff --name-only "origin/$BASE_REF...HEAD")
 
-        # Claude-related files: plugin directories, plugin/marketplace manifests,
-        # per-repo .claude config, CLAUDE.md guidance, and the validation scripts.
+        # Plugin dirs, plugin/marketplace manifests, .claude config, CLAUDE.md, validation scripts.
         RELEVANT=$(echo "$CHANGED_FILES" | grep -E '(^plugins/|(^|/)\.claude-plugin/|(^|/)\.claude/|(^|/)CLAUDE\.md$|(^|/)agents/.*\.md$|(^|/)skills/.*/SKILL\.md$|(^|/)commands/.*\.md$|(^|/)hooks\.json$|^scripts/validate-)' || echo "")
 
         if [[ -z "$RELEVANT" ]]; then
@@ -63,25 +62,19 @@ runs:
         # Unique plugin directories (marketplace repos keep plugins under plugins/<name>/).
         CHANGED_PLUGINS=$(echo "$CHANGED_FILES" | grep '^plugins/' | cut -d/ -f1-2 | sort -u | tr '\n' ' ' | sed 's/ $//' || echo "")
 
-        # Component files drive the AI-driven validation. Agent files appear both as
-        # agents/<name>/AGENT.md and as agents/<name>.md, so match any .md under agents/.
+        # Agents appear as agents/<name>/AGENT.md or agents/<name>.md, so match any .md under agents/.
         AGENT_FILES=$(echo "$RELEVANT" | grep -E '(^|/)agents/.*\.md$' || echo "")
         SKILL_FILES=$(echo "$RELEVANT" | grep -E '(^|/)skills/.*/SKILL\.md$' || echo "")
         COMMAND_FILES=$(echo "$RELEVANT" | grep -E '(^|/)commands/.*\.md$' || echo "")
         HOOK_FILES=$(echo "$RELEVANT" | grep -E '(^|/)hooks\.json$' || echo "")
         CONFIG_FILES=$(echo "$RELEVANT" | grep -E '(^|/)CLAUDE\.md$|(^|/)\.claude/' || echo "")
 
-        # Plugin directories that had an actual component change (agents, skills,
-        # commands, hooks). Version-bump enforcement applies only to these, not to
-        # every touched plugin directory, so a docs-only edit under plugins/<name>
-        # does not force a version bump on that plugin.
+        # Version bumps are enforced only where a component changed, so a docs-only
+        # edit under plugins/<name> does not require one.
         COMPONENT_PLUGINS=$(printf '%s\n' "$AGENT_FILES" "$SKILL_FILES" "$COMMAND_FILES" "$HOOK_FILES" | grep '^plugins/' | cut -d/ -f1-2 | sort -u | tr '\n' ' ' | sed 's/ $//' || echo "")
 
-        # Root marketplace manifest change. Marketplace validation must run for a
-        # manifest-only edit (version, description, removed entry) even when no
-        # plugins/ file changed, so this gates the marketplace step on its own.
-        # Keep it a single-line boolean; a multi-line value would break the
-        # key=value GITHUB_OUTPUT write below.
+        # Gates marketplace validation on its own so a manifest-only edit still runs it.
+        # Must stay single-line: a multi-line value breaks the key=value write below.
         if echo "$RELEVANT" | grep -qE '^\.claude-plugin/'; then
           MARKETPLACE_CHANGED=true
         else
@@ -216,25 +209,12 @@ runs:
         plugins: |
           plugin-dev@claude-code-plugins
           claude-config-validator@bitwarden-marketplace
-        # Bash is granted broadly here rather than scoped to command prefixes
-        # (as run-code-review does) because the plugin-dev plugin-validator agent
-        # shells out to an open-ended, upstream-owned set of inspection commands
-        # that we cannot reliably enumerate; a tight allowlist would break the
-        # review whenever that plugin changes. The write-permission gate in
-        # _validate-ai.yml keeps this to trusted actors.
-        # max-turns bounds turn count, not wall clock, and the two are only loosely
-        # related here: a single Task turn is an entire subagent run, so a review
-        # can spend a quarter of an hour inside a couple of dozen turns. Run
-        # 31699838478 in bitwarden/ai-plugins hit the 15-minute job timeout without
-        # coming near this cap. Treat it as a backstop against a loop, not as the
-        # thing that keeps a review inside its time budget; the job timeout in
-        # _validate-ai.yml is what does that, and a composite step cannot carry a
-        # timeout of its own. Observed runs land in the 25-45 turn range.
+        # Bash is unscoped because the plugin-validator agent shells out to an
+        # open-ended set of upstream-owned commands. The write-permission gate in
+        # _validate-ai.yml limits this to trusted actors.
         #
-        # A timeout kill is survivable either way: the steps that post the sticky
-        # comment run under always(), and GitHub still executes them in the
-        # cancellation window, so the pull request gets the fallback rather than
-        # being left on the "reviewing..." placeholder.
+        # max-turns is a backstop against a loop, not a time bound: one Task turn is
+        # a whole subagent run. Wall clock is bounded by the job timeout.
         claude_args: |
           --verbose
           --model opus
@@ -434,26 +414,16 @@ runs:
         RUN_ID: ${{ github.run_id }}
         COMPONENTS_OUTCOME: ${{ steps.components.outcome }}
       run: |
-        # Claude writes the summary itself. Completeness is decided by the marker
-        # the prompt requires as the report's last line, not by the file existing:
-        # a review that ends mid-flight can leave a partial report behind, and
-        # presence alone accepts that as the final word and posts it to the pull
-        # request under a green check.
-        #
-        # Anything short of a marked report gets a fallback instead, so the sticky
-        # comment reflects the failure rather than being left on the "reviewing..."
-        # placeholder, and summary_missing fails the check (a review that did not
-        # finish must not pass green). Recovery is a re-run of the job, which
-        # starts a clean review.
+        # The trailing marker decides completeness, not the file existing: a review
+        # that ends mid-flight can leave a partial report behind. Anything unmarked is
+        # replaced with a fallback and fails the check.
         if [[ -s /tmp/validation-summary.md ]] && grep -qF '<!-- validation-complete -->' /tmp/validation-summary.md; then
           exit 0
         fi
 
         echo "summary_missing=true" >> "$GITHUB_OUTPUT"
         if [[ -s /tmp/validation-summary.md ]]; then
-          # Move it aside rather than leaving it in place: the step below posts
-          # whatever is at this path, and the partial text must not reach the pull
-          # request. Keep a copy for the log.
+          # A later step posts whatever is at this path, so move the partial aside.
           mv /tmp/validation-summary.md /tmp/validation-summary.partial.md
           echo "::warning::The AI review wrote an incomplete validation summary (no completion marker); discarding it."
           echo "Discarded partial summary:"
@@ -515,9 +485,7 @@ runs:
         echo "Plugin structure validation: ${STRUCTURE_RESULT:-skipped}"
         echo "Marketplace validation: ${MARKETPLACE_RESULT:-skipped}"
         echo "Version bump validation: ${VERSION_BUMP_RESULT:-skipped}"
-        # Report whether a complete report was produced rather than only the step's
-        # exit status: the step can succeed and still end without one, and a bare
-        # "success" on that line reads as though the review landed.
+        # The step can exit 0 without producing a report, so report both.
         if [[ "$SUMMARY_MISSING" == "true" ]]; then
           echo "Component & security validation (AI-driven): ${COMPONENTS_RESULT:-skipped}, but produced no complete report"
         else
@@ -559,10 +527,7 @@ runs:
           echo ""
         fi
 
-        # The AI step can exit 0 having produced no report, or a partial one it
-        # never got to finish (e.g. permission denials, an early exit, or a turn
-        # that ended on work still in flight). Treat either as a failure so the
-        # check never goes green on a review that did not actually finish.
+        # A missing or unfinished report must not pass green.
         if [[ "$SUMMARY_MISSING" == "true" ]]; then
           echo "AI-driven review produced no complete summary; a fallback was posted to the PR comment. Re-run the job to start a fresh review."
           echo ""


### PR DESCRIPTION
## 🎟️ Tracking

Follow-up to #867. The failure it caused is [run 31699838478](https://github.com/bitwarden/ai-plugins/actions/runs/31699838478) in bitwarden/ai-plugins, the first run of the merged action.

## 📔 Objective

That run was killed by `timeout-minutes: 15` with the review still working after 14.85 minutes. Same ten changed files that earlier runs got through in 3.7 and 4.2 minutes, but those runs were only fast because they abandoned the `plugin-validator` and `skill-reviewer` subagents and reported anyway. #867 made the review wait for them, so work that used to be discarded is now actually being done, and it does not fit in 15 minutes.

`--max-turns 80` never fired. One `Task` turn is an entire subagent run, so turn count is a poor proxy for wall clock, and a review can pass a quarter of an hour inside a couple of dozen turns.

### Changes

- `timeout-minutes` goes from 15 to 30 on the `validate` job. The composite step cannot carry a timeout of its own and the turn cap does not bound wall clock, so this is the only limit that applies. Set generously on purpose: no run has completed yet, so there is no real duration to tune against.
- Rule 5 separates synchronous from sequential. It still forbids detaching, and the clause about not ending the turn with a subagent outstanding is untouched, but it now says to dispatch independent subagents together in one message so they overlap and still all return before the turn ends. It also spells out that the fan-out can exceed two, since section 1 is one call per changed plugin and section 2 one per changed skill.
- The section list no longer says "in order". That instruction combined with rule 5 was what serialized the subagents.
- Corrects the `--max-turns` comment, which claimed the cap keeps the review inside its time budget and stops a timeout kill from stranding the sticky comment. The run disproves both halves: the cap did not fire, and the `always()` steps still posted the fallback during the cancellation window.

Two things this does not establish. The concurrency saving is expected rather than measured, since no run has exercised it. And because `show_full_output` is off, I cannot tell whether those 14.85 minutes were genuine work or a stuck subagent; if 30 minutes also proves short, that ambiguity is what needs resolving rather than the number.

Local review raised one IMPORTANT finding, now fixed: the section preamble said section 3 could be carried out "while they run", which describes a window that only exists if the subagents are backgrounded, the exact thing #867 fixed. It now says section 3 happens once their results come back.

## 🚨 Breaking Changes

No interface change, and nothing for consumers to migrate.

`org-validate-ai.yml` runs on every PR in every org repo, so one operational note: a review that needs the extra time now takes up to 30 minutes to report instead of failing red at 15. Slower, but it produces a review rather than a timeout.
