### PR TITLE
[BRE-2133] ci: Add reusable npm publish workflow for @bitwarden/mcp-server

### DIFF
--- a/.github/workflows/_publish-mcp-server-npm.yml
+++ b/.github/workflows/_publish-mcp-server-npm.yml
@@ -1,0 +1,112 @@
+name: _publish-mcp-server-npm
+run-name: Stage publish @bitwarden/mcp-server to npm
+
+# Reusable publish logic for @bitwarden/mcp-server, called by bitwarden/mcp-server's inert
+# publish-npm.yml shim. Living here (locked main, no external contributors) is what lets the
+# shim reference it @main so CD can iterate independently of the CI-built, QA-tested artifact.
+#
+# Runs in the caller's repo context (bitwarden/mcp-server) at the dispatched commit — the
+# publish-release/<version> branch deploy cuts from the release commit. The version is derived
+# from that commit's package.json (the single source of truth; npm publishes that version
+# regardless), and the matching CI-built artifact is promoted from the v<version> release —
+# never rebuilt here.
+#
+# Provenance is issued by npm's trusted publisher only for this exact
+# repo + workflow (publish-npm.yml) + environment (mcp-server-npm); keep this job free of any
+# other OIDC login (e.g. Azure) so the environment-scoped id-token is used solely for npm.
+#
+# This STAGES the publish (`npm stage publish`) rather than publishing directly: the npm
+# trusted publisher for @bitwarden/mcp-server is restricted to stage-only, so a maintainer
+# must approve the staged package on npmjs.com with 2FA before it goes live. Provenance is
+# generated for staged publishes at parity with direct publishes and carries through the
+# approval.
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Stage publish @bitwarden/mcp-server to npm
+    runs-on: ubuntu-24.04
+    environment: mcp-server-npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      # Defense-in-depth: this publish must only ever run from a dispatch by the BRE deploy bot.
+      # If someone runs the mcp-server publish-npm.yml shim by hand (e.g. on main, or
+      # re-dispatches an existing publish-release branch), fail fast before touching the
+      # registry. This is a backstop to the primary controls (environment branch policy +
+      # publish-release ruleset).
+      - name: Verify the run was triggered by the deploy bot
+        env:
+          _TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        run: |
+          if [[ "$_TRIGGERING_ACTOR" != "bre-deploy[bot]" ]]; then
+            echo "::error::Publish must be triggered by bre-deploy[bot]; got '${_TRIGGERING_ACTOR}'"
+            exit 1
+          fi
+
+      # A bare checkout defaults to the CALLER repo (github.* is the caller's context), which
+      # is bitwarden/mcp-server when invoked via its publish-npm.yml shim. Pin it explicitly so
+      # it is also correct from any test caller. github.sha is the caller's commit — the
+      # publish-release/<version> branch deploy cuts from the release commit.
+      - name: Check out bitwarden/mcp-server at the release commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: bitwarden/mcp-server
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Derive version from package.json
+        id: version
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
+            echo "::error::Could not read .version from package.json"
+            exit 1
+          fi
+          echo "Resolved version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: "https://registry.npmjs.org/"
+          cache: npm
+
+      - name: Pin npm version
+        run: |
+          # npm 11.5.1+ required for OIDC trusted publishing + provenance; 11.15.0+ for `npm stage`.
+          npm install -g npm@latest
+          npm --version
+
+      # package.json has `"prepare": "husky"`, which npm runs as part of `npm publish` /
+      # `npm stage publish`. Without node_modules that lifecycle script fails and takes the
+      # publish with it (BRE-1960). `--ignore-scripts` keeps the install itself from executing
+      # any dependency scripts inside this OIDC-bearing job.
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      # Promote the CI-built, QA-tested bundle: download the build zip attached to the
+      # v<version> release and unpack it at the repo root, which restores dist/ exactly as
+      # package.json `files: ["dist"]` expects. npm force-includes README.md + LICENSE.txt +
+      # package.json from the working tree (already present via the checkout). mcp-server is
+      # public, so the job's GITHUB_TOKEN (contents: read) can download the release asset.
+      - name: Download and unpack npm build
+        env:
+          GH_TOKEN: ${{ github.token }}
+          _PKG_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh release download "v${_PKG_VERSION}" \
+            --repo bitwarden/mcp-server \
+            --pattern "mcp-server-${_PKG_VERSION}.zip"
+          unzip "mcp-server-${_PKG_VERSION}.zip"
+
+      # Stages the publish with provenance. A maintainer must approve it on npmjs.com (2FA)
+      # before the version is live — bitwarden/deploy notifies #release when this completes.
+      - name: Stage publish to npm with provenance
+        run: npm stage publish --provenance --access public


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BRE-2133

Implements the pattern determined in [BRE-2047](https://bitwarden.atlassian.net/browse/BRE-2047) and documented in [`bitwarden/deploy` `docs/secure-publishing-public-repository.md`](https://github.com/bitwarden/deploy/blob/main/docs/secure-publishing-public-repository.md) §6 D. Follows [BRE-2118](https://bitwarden.atlassian.net/browse/BRE-2118) / `_publish-cli-npm.yml` as the reference implementation.

## 📔 Objective

Adds `_publish-mcp-server-npm.yml`, the real npm publish logic for `@bitwarden/mcp-server`, called by that repo's inert `publish-npm.yml` shim.

npm only issues a provenance attestation when the publish runs from the public source repo, so the publish has to move out of `bitwarden/deploy` and into `bitwarden/mcp-server`. The logic can't live in the public repo either — it has external contributors — so it lives here, where `main` is locked and non-contributable. That's what puts a two-account bar on the publish logic itself, and what lets the shim reference this `@main` rather than SHA-pinned, keeping CD able to iterate independently of the CI-built, QA-tested artifact.

What it does, in the caller's repo context at the dispatched commit:

1. assert `github.triggering_actor` is `bre-deploy[bot]` and fail fast otherwise
2. check out `bitwarden/mcp-server` at `github.sha` (the `publish-release/<version>` branch deploy cut from the release commit)
3. derive the version from that commit's `package.json` — the single source of truth
4. promote the CI-built artifact: download `mcp-server-<version>.zip` from the `v<version>` release and unpack it at the repo root, restoring `dist/` where `files: ["dist"]` expects it. **Nothing is rebuilt.**
5. `npm stage publish --provenance --access public`

The job has `environment: mcp-server-npm` and `permissions: { contents: read, id-token: write }`, and deliberately contains **no other OIDC login** (no Azure) so the environment-scoped id-token is used solely for npm.

### Differences from `_publish-cli-npm.yml`

Three, all deliberate and commented in-file:

| | Why |
|---|---|
| `cache: npm` on `setup-node` | this workflow runs `npm ci`, the CLI one doesn't |
| `npm ci --ignore-scripts` | `mcp-server`'s `package.json` has `"prepare": "husky"`, which npm runs during publish and which fails without `node_modules` — [BRE-1960](https://bitwarden.atlassian.net/browse/BRE-1960) fixed exactly this in production. `--ignore-scripts` keeps the install itself from executing any dependency scripts inside the OIDC-bearing job. |
| `npm stage publish` instead of `npm publish` | `@bitwarden/mcp-server`'s npm trusted publisher is restricted to **stage-only** ([BRE-1947](https://bitwarden.atlassian.net/browse/BRE-1947), Checkmarx incident response), so a maintainer approves the staged package on npmjs.com with 2FA before it goes live. Provenance is [generated for staged publishes at parity with direct publishes](https://github.com/orgs/community/discussions/196675) and carries through the approval. A stage-only config *rejects* plain `npm publish`. |

Otherwise it is parity with the CLI version — no guard added, none dropped.

### Companion PRs — merge order matters

1. `bitwarden/mcp-server` — the inert shim (branch `bre-2133/npm-provenance-mcp-server`)
2. **this PR**
3. `bitwarden/deploy` — the trust root that dispatches the shim (same branch name)
4. repoint the npm trusted publisher

This is inert until the shim calls it, so it is safe to land early. It must land before `deploy`, or the dispatched shim run fails resolving this workflow.


[BRE-2047]: https://bitwarden.atlassian.net/browse/BRE-2047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRE-2118]: https://bitwarden.atlassian.net/browse/BRE-2118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRE-1960]: https://bitwarden.atlassian.net/browse/BRE-1960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ