### PR TITLE
fix(run-code-review): install plugin-dev so skill review can run

### DIFF
--- a/run-code-review/action.yml
+++ b/run-code-review/action.yml
@@ -90,8 +90,11 @@ runs:
       with:
         anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-CODE-REVIEW-API-KEY }}
         allowed_bots: "aikido-autofix[bot]"
-        plugin_marketplaces: "https://github.com/bitwarden/ai-plugins.git"
+        plugin_marketplaces: |
+          https://github.com/anthropics/claude-code.git
+          https://github.com/bitwarden/ai-plugins.git
         plugins: |
+          plugin-dev@claude-code-plugins
           bitwarden-code-review@bitwarden-marketplace
           bitwarden-software-engineer@bitwarden-marketplace
           bitwarden-security-engineer@bitwarden-marketplace


### PR DESCRIPTION
## 🎟️ Tracking

Paired with bitwarden/ai-plugins#206, which routes changed `SKILL.md` files to `plugin-dev:skill-reviewer`. That change has no effect in CI without this one.

## 📔 Objective

`run-code-review` registers a single plugin marketplace, `bitwarden/ai-plugins`, and installs four Bitwarden plugins from it. `plugin-dev` is published by `anthropics/claude-code`, so nothing in the current list can resolve it.

bitwarden/ai-plugins#206 gives `bitwarden-code-review` two paths that delegate to the `plugin-dev:skill-reviewer` agent: Agent 5 in the multi-agent pipeline, and a `Task` delegation in the single-agent reviewer. Both fall back to a "skill review did not run" note when the plugin is absent. Without this change, every pull request touching a `SKILL.md` gets that note instead of a review.

`Task` is already in the action's `--allowedTools`, so the tool grant needs no change.

`validate-ai/action.yml` already does the same thing for `plugin-dev:plugin-validator`. This copies that arrangement: register `anthropics/claude-code` alongside the Bitwarden marketplace, then install `plugin-dev@claude-code-plugins`.

## 🚨 Breaking Changes

None. This adds a marketplace and a plugin to the review environment. No inputs, outputs, or defaults change.
