### PR TITLE
[VULN-928] fix: Remove raw prompt splice and block Read of .git in respond workflow

### DIFF
--- a/.github/workflows/_respond.yml
+++ b/.github/workflows/_respond.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Log in to Azure
         uses: bitwarden/gh-actions/azure-login@main
@@ -127,7 +127,7 @@ jobs:
             bitwarden-software-engineer@bitwarden-marketplace
             bitwarden-security-engineer@bitwarden-marketplace
             claude-config-validator@bitwarden-marketplace
-          prompt: ${{ github.event.comment.body || github.event.review.body || github.event.issue.body }}
           claude_args: |
             --model opus
             --allowedTools "mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --disallowedTools "Read(./.git/**)"


### PR DESCRIPTION
## 🎟️ Tracking

PM-42362 / VULN-928

## 📔 Objective

The respond workflow spliced raw, attacker-controlled comment and issue text directly into the Claude Code action's `prompt:` input, landing in an unsanitized **`<custom_instructions>`** tag the model treats as an operator command rather than the action's own sanitized trigger-comment path. We also closed a related gap where Claude's **`Read`** tool could reach a write-scoped GitHub token the action itself writes into `.git/config`, independent of what the checkout step persists. This removes the raw `prompt:` input and adds a path-scoped **deny rule** blocking `Read` access under `.git/`.
