### PR TITLE
fix(update-pr-comment): stop gh expanding placeholders inside the comment body

### DIFF
--- a/.github/workflows/test-update-pr-comment.yml
+++ b/.github/workflows/test-update-pr-comment.yml
@@ -45,10 +45,12 @@ jobs:
           pr_number: ${{ steps.pr.outputs.number }}
           repository: ${{ github.repository }}
           marker_id: test-upsert-comment
-          body: "Test comment created by test-create job."
+          body: "Test comment created by test-create job. Placeholder tokens: {owner}/{repo}@{branch}"
 
       - name: Verify comment was created
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
           COMMENT_ID: ${{ steps.upsert.outputs.comment_id }}
           COMMENT_URL: ${{ steps.upsert.outputs.comment_url }}
           COMMENT_CREATED: ${{ steps.upsert.outputs.comment_created }}
@@ -64,6 +66,12 @@ jobs:
 
           if [[ "$COMMENT_CREATED" != "true" ]]; then
             echo "::error::Expected comment_created=true, got $COMMENT_CREATED"
+            exit 1
+          fi
+
+          POSTED=$(gh api "repos/${REPOSITORY}/issues/comments/${COMMENT_ID}" --jq .body)
+          if [[ "$POSTED" != *'{branch}'* ]]; then
+            echo "::error::Placeholder tokens did not survive; body was: $POSTED"
             exit 1
           fi
 
@@ -102,7 +110,7 @@ jobs:
           pr_number: ${{ steps.pr.outputs.number }}
           repository: ${{ github.repository }}
           marker_id: test-upsert-comment
-          body: "Test comment updated by test-update job."
+          body: "Test comment updated by test-update job. Placeholder tokens: {owner}/{repo}@{branch}"
 
       - name: Verify comment was updated
         env:
@@ -142,7 +150,7 @@ jobs:
 
           gh api "repos/${REPOSITORY}/issues/comments/${COMMENT_ID}" \
             --method PATCH \
-            --field body="$FINAL_BODY"
+            --raw-field body="$FINAL_BODY"
 
           echo "Successfully updated comment $COMMENT_ID with final content"
 

--- a/update-pr-comment/action.yml
+++ b/update-pr-comment/action.yml
@@ -124,9 +124,10 @@ runs:
 
         if [[ -z "$EXISTING_ID" ]]; then
           echo "No existing comment found, creating new comment"
+          # --raw-field: --field would expand {owner}, {repo}, {branch} inside the body.
           RESPONSE=$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
             --method POST \
-            --field body="$BODY")
+            --raw-field body="$BODY")
 
           COMMENT_ID=$(echo "$RESPONSE" | jq -r '.id')
           COMMENT_URL=$(echo "$RESPONSE" | jq -r '.html_url')
@@ -135,7 +136,7 @@ runs:
           echo "Updating comment: $EXISTING_ID"
           RESPONSE=$(gh api "repos/${REPOSITORY}/issues/comments/${EXISTING_ID}" \
             --method PATCH \
-            --field body="$BODY")
+            --raw-field body="$BODY")
 
           COMMENT_ID=$(echo "$RESPONSE" | jq -r '.id')
           COMMENT_URL=$(echo "$RESPONSE" | jq -r '.html_url')


### PR DESCRIPTION
## 🎟️ Tracking

No Jira ticket. Found from a real failure: the `Validate` job on [bitwarden/ai-plugins#217](https://github.com/bitwarden/ai-plugins/pull/217) ran every check green and then failed while posting its report.

## 📔 Objective

`gh api --field` expands `{owner}`, `{repo}`, and `{branch}` inside the value it is handed, not just inside the endpoint. `update-pr-comment` passes the comment body through `--field`, so any body quoting one of those tokens takes the expansion path. A GitHub Actions runner checks out in detached HEAD, so resolving `{branch}` has nothing to resolve against and `gh` exits 1:

```
error parsing "body" value: could not determine current branch: failed to run git: not on any branch
```

On #217 the report quoted a skill file containing `repos/{owner}/{repo}/code-scanning/alerts?ref=refs/heads/{branch}`, which is ordinary content for a validation report to include. Any body carrying documentation or code samples of GitHub API paths hits the same thing, and the failure looks like a validation failure rather than a comment-posting one.

`--raw-field` sends the string verbatim with no expansion, which is what a comment body wants. Reproduced both directions in a detached-HEAD repo:

```
$ gh api -X GET repos/bitwarden/ai-plugins --field foo='{branch}'
error parsing "foo" value: could not determine current branch: failed to run git: not on any branch

$ gh api -X GET repos/bitwarden/ai-plugins --raw-field foo='{branch}'
{"id":1080721912, ...}
```

The action's own test workflow used `--field` for its downstream update and now matches. Its create and update bodies carry the placeholder tokens, and the create job asserts they survive in the posted comment, so the path stays covered.

## 🚨 Breaking Changes

None. `--raw-field` sends the same string for every body that does not contain a placeholder token, and bodies that do contain one previously failed outright rather than posting.


## ✅ How this was verified

The action's own test suite exercises this PR's code, because `test-update-pr-comment.yml` calls `./update-pr-comment` by path. All four jobs pass, and `Test create comment` now asserts the placeholder tokens survive into the posted comment.

The failing `Review / Review` check is expected until this merges, and it is this exact bug. `run-code-review/action.yml` and `validate-ai/action.yml` both call `bitwarden/gh-actions/update-pr-comment@main`, so the review job runs the unfixed version from `main` rather than the fix on this branch. Its report quotes the `{owner}`, `{repo}`, and `{branch}` tokens out of this diff, which is what tips the old code over. The red check is the bug reproducing itself against the PR that fixes it.

Behavior confirmed directly from a detached HEAD, matching a runner checkout:

```
$ gh api repos/OWNER/REPO/issues/220/comments --method POST \
    --raw-field body='Literal tokens: repos/{owner}/{repo}/alerts?ref=refs/heads/{branch}'
$ gh api repos/OWNER/REPO/issues/comments/$ID --jq .body
Literal tokens: repos/{owner}/{repo}/alerts?ref=refs/heads/{branch}
```

The same call with `--field` fails instead of posting.
